### PR TITLE
Faster Catmull-Rom interpolation of Array and Numo::NArray

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 PATH
   remote: .
   specs:
-    mb-math (0.1.3.1.usegit)
+    mb-math (0.1.3.2.usegit)
       cmath (~> 1.0.0)
       mb-util (>= 0.1.0.usegit)
       numo-narray (~> 0.9.1)

--- a/lib/mb/m/interpolation_methods.rb
+++ b/lib/mb/m/interpolation_methods.rb
@@ -50,7 +50,7 @@ module MB
           }
         else
           blend = func.call(blend) if func
-          (1 - blend) * a + blend * b
+          a * (1 - blend) + b * blend
         end
       end
 

--- a/lib/mb/m/interpolation_methods.rb
+++ b/lib/mb/m/interpolation_methods.rb
@@ -71,7 +71,7 @@ module MB
           p3 = Numo::NArray.cast(p3)
         end
 
-        # The distance between points is is used to space control "knots" t0..t3
+        # The distance between points is used to space control "knots" t0..t3
         if alpha != 0
           a = 0.5 * alpha # bake square root into alpha
           t0 = 0.0
@@ -99,13 +99,30 @@ module MB
         d1t = t1 - t
         d2t = t2 - t
         d3t = t3 - t
-        a1 = d1t / d10 * p0 - d0t / d10 * p1
-        a2 = d2t / d21 * p1 - d1t / d21 * p2
-        a3 = d3t / d32 * p2 - d2t / d32 * p3
-        b1 = d2t / d20 * a1 - d0t / d20 * a2
-        b2 = d3t / d31 * a2 - d1t / d31 * a3
 
-        d2t / d21 * b1 - d1t / d21 * b2
+        if p0.is_a?(Numo::NArray)
+          a1 = p0 * (d1t / d10)
+          a1.inplace - (p1 * (d0t / d10))
+          a2 = p1 * (d2t / d21)
+          a2.inplace - (p2 * (d1t / d21))
+          a3 = p2 * (d3t / d32)
+          a3.inplace - (p3 * (d2t / d32))
+
+          b1 = (a1.inplace * (d2t / d20)).not_inplace!
+          b1.inplace - (a2 * (d0t / d20))
+          b2 = (a2.inplace * (d3t / d31)).not_inplace!
+          b2.inplace - (a3 * (d1t / d31))
+
+          ((b1.inplace * (d2t / d21)).inplace - (b2.inplace * (d1t / d21))).not_inplace!
+        else
+          a1 = p0 * (d1t / d10) - p1 * (d0t / d10)
+          a2 = p1 * (d2t / d21) - p2 * (d1t / d21)
+          a3 = p2 * (d3t / d32) - p3 * (d2t / d32)
+          b1 = a1 * (d2t / d20) - a2 * (d0t / d20)
+          b2 = a2 * (d3t / d31) - a3 * (d1t / d31)
+
+          b1 * (d2t / d21) - b2 * (d1t / d21)
+        end
       end
 
       private

--- a/lib/mb/m/interpolation_methods.rb
+++ b/lib/mb/m/interpolation_methods.rb
@@ -131,8 +131,22 @@ module MB
       def cr_distance_squared(p1, p2)
         p1 = [0, p1] if p1.is_a?(Numeric)
         p2 = [1, p2] if p2.is_a?(Numeric)
-        # TODO: this could be made faster without transposing
-        [p2.to_a, p1.to_a].transpose.map { |v| (v[1] - v[0]).abs ** 2 }.sum
+
+        case p1.length
+        when 2
+          (p2[0] - p1[0]).abs ** 2 + (p2[1] - p1[1]).abs ** 2
+
+        when 3
+          (p2[0] - p1[0]).abs ** 2 + (p2[1] - p1[1]).abs ** 2 + (p2[2] - p1[2]).abs ** 2
+
+        when 4
+          (p2[0] - p1[0]).abs ** 2 + (p2[1] - p1[1]).abs ** 2 + (p2[2] - p1[2]).abs ** 2 + (p2[3] - p1[3]).abs ** 2
+
+        else
+          p1.length.times.reduce(0) { |obj, idx|
+            obj + (p2[idx] - p1[idx]).abs ** 2
+          }
+        end
       end
     end
   end

--- a/lib/mb/m/interpolation_methods.rb
+++ b/lib/mb/m/interpolation_methods.rb
@@ -111,7 +111,7 @@ module MB
           b1 = (a1.inplace * (d2t / d20)).not_inplace!
           b1.inplace - (a2 * (d0t / d20))
           b2 = (a2.inplace * (d3t / d31)).not_inplace!
-          b2.inplace - (a3 * (d1t / d31))
+          b2.inplace - (a3.inplace * (d1t / d31))
 
           ((b1.inplace * (d2t / d21)).inplace - (b2.inplace * (d1t / d21))).not_inplace!
         else

--- a/lib/mb/m/version.rb
+++ b/lib/mb/m/version.rb
@@ -1,5 +1,5 @@
 module MB
   module M
-    VERSION = "0.1.3.1.usegit"
+    VERSION = "0.1.3.2.usegit"
   end
 end

--- a/spec/lib/mb/m/interpolation_methods_spec.rb
+++ b/spec/lib/mb/m/interpolation_methods_spec.rb
@@ -176,10 +176,34 @@ RSpec.describe(MB::M::InterpolationMethods) do
       expect(result.diff.min).to be > 0
     end
 
-    it 'can interpolate arrays' do
-      result = MB::M.catmull_rom([1, 5], [3, 3], [-2.5, 4.5], [-1, 4], 0.25, 0)
+    it 'can interpolate arrays of length 2' do
+      result = MB::M.catmull_rom([1, 5], [3, 3], [-2.5, 4.5], [-1, 4], 0.25, 0.1)
       expect(result[0]).to be_between(-2.6, 2.9)
       expect(result[1]).to be_between(3.1, 4.4)
+    end
+
+    it 'can interpolate arrays of length 3' do
+      result = MB::M.catmull_rom([1, 5, 1], [3, 3, 3], [-2.5, 4.5, -2.5], [-1, 4, -1], 0.25, 0.1)
+      expect(result[0]).to be_between(-2.6, 2.9)
+      expect(result[1]).to be_between(3.1, 4.4)
+      expect(result[2]).to be_between(-2.6, 2.9)
+    end
+
+    it 'can interpolate narrays of length 4' do
+      result = MB::M.catmull_rom(Numo::SFloat[1, 5, 1, 5], Numo::SFloat[3, 3, 3, 3], Numo::SFloat[-2.5, 4.5, -2.5, 4.5], Numo::SFloat[-1, 4, -1, 4], 0.25, 0.1)
+      expect(result[0]).to be_between(-2.6, 2.9)
+      expect(result[1]).to be_between(3.1, 4.4)
+      expect(result[2]).to be_between(-2.6, 2.9)
+      expect(result[3]).to be_between(3.1, 4.4)
+    end
+
+    it 'can interpolate narrays of length 5' do
+      result = MB::M.catmull_rom(Numo::SFloat[1, 5, 1, 5, 1], Numo::SFloat[3, 3, 3, 3, 3], Numo::SFloat[-2.5, 4.5, -2.5, 4.5, -2.5], Numo::SFloat[-1, 4, -1, 4, -1], 0.25, 0.1)
+      expect(result[0]).to be_between(-2.6, 2.9)
+      expect(result[1]).to be_between(3.1, 4.4)
+      expect(result[2]).to be_between(-2.6, 2.9)
+      expect(result[3]).to be_between(3.1, 4.4)
+      expect(result[4]).to be_between(-2.6, 2.9)
     end
 
     it 'does something with alpha' do


### PR DESCRIPTION
This speeds up the distance calculation for Catmull-Rom control point spacing, and uses in-place operations on Numo::NArray where possible.