### PR TITLE
Allow pad, zpad, and opad to accept a block for padded processing.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,15 +20,15 @@ GEM
     coderay (1.1.3)
     diff-lcs (1.4.4)
     docile (1.4.0)
-    method_source (1.0.0)
+    method_source (1.1.0)
     numo-narray (0.9.2.0)
-    pry (0.14.1)
+    pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
     pry-byebug (3.8.0)
       byebug (~> 11.0)
       pry (~> 0.10)
-    pry-doc (1.1.0)
+    pry-doc (1.5.0)
       pry (~> 0.11)
       yard (~> 0.9.11)
     rake (13.0.3)
@@ -51,7 +51,7 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.3)
-    yard (0.9.26)
+    yard (0.9.36)
 
 PLATFORMS
   ruby

--- a/lib/mb/m/array_methods.rb
+++ b/lib/mb/m/array_methods.rb
@@ -139,10 +139,14 @@ module MB
         target
       end
 
-      # Returns a new array padded with the given +value+ (or +before+ before and
-      # +after+ after) to provide a size of at least +min_length+.  Returns the
-      # original array if it is already long enough.  The default value is zero if
-      # not specified.
+      # If no block is given, returns a new array padded with the given +value+
+      # (or +before+ before and +after+ after) to provide a size of at least
+      # +min_length+.  Returns the original array if it is already long enough.
+      # The default value is zero if not specified.
+      #
+      # If a block is given, the padded array is yielded to the block, the
+      # padding regions are removed from whatever the block returns (must be
+      # the same length narray as given to the block), and the result returned.
       #
       # Use 0 for +alignment+ to leave the original data at the start of the
       # resulting array, 1 to leave it at the end of the array, and something in
@@ -176,23 +180,28 @@ module MB
           end
         end
 
-        narray
+        if block_given?
+          result = yield narray
+          result[length_before..-(length_after + 1)]
+        else
+          narray
+        end
       end
 
       # Returns a new array padded with zeros to provide a size of at least
       # +min_length+.  Returns the original array if it is already long enough.
       #
-      # See #pad for +alignment+.
-      def zpad(narray, min_length, alignment: 0)
-        pad(narray, min_length, value: 0, alignment: alignment)
+      # See #pad for +alignment+ and block behavior.
+      def zpad(narray, min_length, alignment: 0, &bl)
+        pad(narray, min_length, value: 0, alignment: alignment, &bl)
       end
 
       # Returns a new array padded with ones to provide a size of at least
       # +min_length+.  Returns the original array if it is already long enough.
       #
-      # See #pad for +alignment+.
-      def opad(narray, min_length, alignment: 0)
-        pad(narray, min_length, value: 1, alignment: alignment)
+      # See #pad for +alignment+ and block behavior.
+      def opad(narray, min_length, alignment: 0, &bl)
+        pad(narray, min_length, value: 1, alignment: alignment, &bl)
       end
 
       # Rotates a 1D NArray left by +n+ places, which must be less than the

--- a/spec/lib/mb/m/array_methods_spec.rb
+++ b/spec/lib/mb/m/array_methods_spec.rb
@@ -266,6 +266,23 @@ RSpec.describe(MB::M::ArrayMethods) do
         end
       end
     end
+
+    context 'when a block is given' do
+      it 'returns the original data if the block does not modify the padded data' do
+        data = Numo::SFloat.linspace(-1, -2, 100)
+
+        padded = nil
+        result = MB::M.pad(data, 150, before: 1, after: 2, alignment: 0.25) do |p| padded = p end
+        expect(result).to eq(data)
+        expect(padded.length).to eq(150)
+      end
+
+      it 'returns data as modified by the block' do
+        data = Numo::SFloat.linspace(-1, -2, 127)
+        result = MB::M.pad(data, 139, before: 2, after: 1, alignment: 0.37) do |p| p * 2 end
+        expect(result).to eq(data * 2)
+      end
+    end
   end
 
   describe '.zpad' do
@@ -276,6 +293,12 @@ RSpec.describe(MB::M::ArrayMethods) do
     it 'can pad an empty narray' do
       expect(MB::M.zpad(Numo::SFloat[], 2)).to eq(Numo::SFloat[0, 0])
     end
+
+    context 'when a block is given' do
+      it 'returns original length data as modified by the block' do
+        expect(MB::M.zpad(Numo::SFloat.zeros(3), 5) { |p| p + 1 }).to eq(Numo::SFloat.ones(3))
+      end
+    end
   end
 
   describe '.opad' do
@@ -285,6 +308,12 @@ RSpec.describe(MB::M::ArrayMethods) do
 
     it 'can pad an empty narray' do
       expect(MB::M.opad(Numo::SFloat[], 2)).to eq(Numo::SFloat[1, 1])
+    end
+
+    context 'when a block is given' do
+      it 'returns original length data as modified by the block' do
+        expect(MB::M.zpad(Numo::SFloat.zeros(3), 5) { |p| p + 3 }).to eq(Numo::SFloat.ones(3) * 3)
+      end
     end
   end
 


### PR DESCRIPTION
This enables processing of padded data without having to manage removal of the padding.

```ruby
MB::M.zpad(Numo::SFloat[1,2,3], 5, alignment: 0.5) do |d| puts MB::U.highlight(d); d.reverse end
Numo::SFloat#shape=[5]
[0, 1, 2, 3, 0]
=> Numo::SFloat(view)#shape=[3]
[3, 2, 1]
```