### PR TITLE
Fix pad/zpad/opad block handling when narray is already long enough.

### DIFF
--- a/lib/mb/m/array_methods.rb
+++ b/lib/mb/m/array_methods.rb
@@ -152,7 +152,18 @@ module MB
       # resulting array, 1 to leave it at the end of the array, and something in
       # between to place it in the middle (e.g. 0.5 for centering the data).
       def pad(narray, min_length, value: nil, before: nil, after: nil, alignment: 0)
-        return narray if narray.size >= min_length
+        if narray.size >= min_length
+          if block_given?
+            result = yield narray
+            if result.shape != narray.shape
+              raise "Block result shape #{result.shape} does not match provided shape #{narray.shape}"
+            end
+
+            return result
+          end
+
+          return narray
+        end
 
         value ||= 0
         before ||= value
@@ -182,6 +193,9 @@ module MB
 
         if block_given?
           result = yield narray
+          if result.shape != narray.shape
+            raise "Block result shape #{result.shape} does not match provided shape #{narray.shape}"
+          end
           result[length_before..-(length_after + 1)]
         else
           narray

--- a/lib/mb/m/version.rb
+++ b/lib/mb/m/version.rb
@@ -1,5 +1,5 @@
 module MB
   module M
-    VERSION = "0.1.10.usegit"
+    VERSION = "0.1.11.usegit"
   end
 end

--- a/spec/lib/mb/m/array_methods_spec.rb
+++ b/spec/lib/mb/m/array_methods_spec.rb
@@ -282,6 +282,22 @@ RSpec.describe(MB::M::ArrayMethods) do
         result = MB::M.pad(data, 139, before: 2, after: 1, alignment: 0.37) do |p| p * 2 end
         expect(result).to eq(data * 2)
       end
+
+      it 'still yields to the block if the data is already long enough' do
+        data = Numo::SFloat[1, 2, 3]
+        padded = nil
+        result = MB::M.pad(data, 3, value: 0.5) do |p| padded = p end
+        expect(result).to eq(data)
+        expect(padded).to eq(data)
+      end
+
+      it 'still yields to the block if the data is already longer' do
+        data = Numo::SFloat[1, 2, 3]
+        padded = nil
+        result = MB::M.pad(data, 0, value: 0.5) do |p| padded = p end
+        expect(result).to eq(data)
+        expect(padded).to eq(data)
+      end
     end
   end
 
@@ -296,7 +312,15 @@ RSpec.describe(MB::M::ArrayMethods) do
 
     context 'when a block is given' do
       it 'returns original length data as modified by the block' do
-        expect(MB::M.zpad(Numo::SFloat.zeros(3), 5) { |p| p + 1 }).to eq(Numo::SFloat.ones(3))
+        expect(MB::M.zpad(Numo::SFloat.ones(3), 5) { |p| p + 1 }).to eq(Numo::SFloat.ones(3) * 2)
+      end
+
+      it 'works when the data is already long enough' do
+        expect(MB::M.zpad(Numo::SFloat.ones(3), 3) { |p| Numo::SFloat[4, 3, 2] }).to eq(Numo::SFloat[4, 3, 2])
+      end
+
+      it 'works when the data is already longer' do
+        expect(MB::M.zpad(Numo::SFloat.ones(3), 1) { |p| Numo::SFloat[1, 2, 3] }).to eq(Numo::SFloat[1, 2, 3])
       end
     end
   end
@@ -313,6 +337,14 @@ RSpec.describe(MB::M::ArrayMethods) do
     context 'when a block is given' do
       it 'returns original length data as modified by the block' do
         expect(MB::M.zpad(Numo::SFloat.zeros(3), 5) { |p| p + 3 }).to eq(Numo::SFloat.ones(3) * 3)
+      end
+
+      it 'works when the data is already long enough' do
+        expect(MB::M.zpad(Numo::SFloat.zeros(3), 3) { |p| Numo::SFloat.ones(3) }).to eq(Numo::SFloat.ones(3))
+      end
+
+      it 'works when the data is already longer' do
+        expect(MB::M.zpad(Numo::SFloat.zeros(3), 1) { |p| Numo::SFloat[1, 2, 3] }).to eq(Numo::SFloat[1, 2, 3])
       end
     end
   end


### PR DESCRIPTION
Prior to this fix, the block would not be called if the given narray length was already >= the requested length.