### PR TITLE
Recursive/deep weighted sum and arithmetic on Hashes and Arrays

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 PATH
   remote: .
   specs:
-    mb-math (0.2.2.usegit)
+    mb-math (0.2.3.usegit)
       bigdecimal (~> 3.1.8)
       cmath (~> 1.0.0)
       matrix (~> 0.4.2)

--- a/lib/mb/m/interpolation_methods.rb
+++ b/lib/mb/m/interpolation_methods.rb
@@ -137,7 +137,7 @@ module MB
       # detection and reporting.
       def very_deep_math(a, operation, b, path: [], visited: {})
         # TODO: better name
-        # TODO: can we handle cycles by ensuring that both a and b have the same cyclic structure?
+        return visited[a] if visited.include?(a) && visited[a].equal?(visited[b])
         raise 'Cycle detected' if visited.include?(a) || visited.include?(b)
 
         if a.is_a?(Hash) && b.is_a?(Hash)

--- a/lib/mb/m/interpolation_methods.rb
+++ b/lib/mb/m/interpolation_methods.rb
@@ -123,6 +123,7 @@ module MB
             raise ArgumentError, "Unknown operation #{operation.inspect}"
           end
         end
+
       rescue => e
         raise if e.message.start_with?('Error at')
         raise e.class, "#{path_string(path, prefix: 'Error at ')}: #{e.message}", e.backtrace

--- a/lib/mb/m/interpolation_methods.rb
+++ b/lib/mb/m/interpolation_methods.rb
@@ -67,33 +67,40 @@ module MB
       # Recursively applies +:operation+ against +scalar+ to each nested value
       # in +data+, traversing through Hashes and Arrays.
       #
+      # The +:path+ and +:visited+ parameters are used internally for error
+      # detection and reporting.
+      #
+      # This function preserves cycles in the data structure by replacing the
+      # cyclic reference with its modified output value.
+      #
       # Examples:
-      #     deep_math({a: 1, b: [2, 3], 2, operation: :*)
+      #     deep_math({a: 1, b: [2, 3]}, :*, 2)
       #     => {a: 2, b: [4, 6]}
       #
-      #     deep_math(['a', 'b'], 3, operation: :*)
+      #     deep_math(['a', 'b'], :*, 3)
       #     => ['aaa', 'bbb']
-      def deep_math(data, scalar, operation:, path: [], visited: {})
-        # TODO: would deep_math(data, operation, scalar) be a better argument layout?
-        # XXX require 'pry-byebug' ; binding.pry # XXX
-        #raise "Cycle detected with visited #{visited}" if visited.include?(data) # XXX
-        raise 'Super deep!' if path.length > 100 # XXX
+      #
+      #     # Cycle
+      #     a = [1, 2]
+      #     a << a
+      #     deep_math(a, :+, 4)
+      #     => [5, 6, [...]]
+      #
+      def deep_math(data, operation, scalar, path: [], visited: {})
         return visited[data] if visited.include?(data)
 
         case data
         when Hash
           visited[data] = {}
-          data.map.with_object(visited[data]) { |(k, v), h|
-            h[k] = deep_math(v, scalar, operation: operation, path: path + [k], visited: visited)
-          }.to_h
-          visited[data]
+          data.each_with_object(visited[data]) { |(k, v), h|
+            h[k] = deep_math(v, operation, scalar, path: path + [k], visited: visited)
+          }
 
         when Array
           visited[data] = Array.new(data.length)
-          data.each_with_index { |v, idx|
-            visited[data][idx] = deep_math(v, scalar, operation: operation, path: path + [idx], visited: visited)
-          }
-          visited[data]
+          data.each_with_index.with_object(visited[data]) do |(v, idx), arr|
+            arr[idx] = deep_math(v, operation, scalar, path: path + [idx], visited: visited)
+          end
 
         else
           case operation
@@ -125,33 +132,36 @@ module MB
       # +a+ and +b+, traversing through Hashes and Arrays.  Raises an error if
       # +a+ and +b+ have different schemas, unless +b+ has a Numeric where +a+
       # has a traversable data structure.
-      def very_deep_math(a, b, operation:, path: [], visited: {})
+      #
+      # The +:path+ and +:visited+ parameters are used internally for error
+      # detection and reporting.
+      def very_deep_math(a, operation, b, path: [], visited: {})
         # TODO: better name
-        # TODO: can we handle cycles by ensuring that both a and b are in visited?
+        # TODO: can we handle cycles by ensuring that both a and b have the same cyclic structure?
         raise 'Cycle detected' if visited.include?(a) || visited.include?(b)
 
         if a.is_a?(Hash) && b.is_a?(Hash)
           raise 'Hash a and b do not have the same keys' unless a.keys == b.keys
 
-          visited[a] = true
-          visited[b] = true
+          visited[a] = {}
+          visited[b] = visited[a]
 
-          a.map { |k, v|
-            [k, very_deep_math(a[k], b[k], operation: operation, path: path + [k], visited: visited)]
-          }.to_h
+          a.each_with_object(visited[a]) { |(k, v), h|
+            h[k] = very_deep_math(a[k], operation, b[k], path: path + [k], visited: visited)
+          }
 
         elsif a.is_a?(Array) && b.is_a?(Array)
           raise 'Array a and b do not have the same length' unless a.length == b.length
 
-          visited[a] = true
-          visited[b] = true
+          visited[a] = Array.new(a.length)
+          visited[b] = visited[a]
 
-          a.map.with_index { |v, idx|
-            very_deep_math(a[idx], b[idx], operation: operation, path: path + [idx], visited: visited)
+          a.each_with_index.with_object(visited[a]) { |(v, idx), arr|
+            arr[idx] = very_deep_math(a[idx], operation, b[idx], path: path + [idx], visited: visited)
           }
 
         else
-          deep_math(a, b, operation: operation, path: path, visited: visited)
+          deep_math(a, operation, b, path: path, visited: visited)
         end
 
       rescue => e
@@ -159,17 +169,19 @@ module MB
         raise e.class, "#{path_string(path, prefix: 'Error at ')}: #{e.message}", e.backtrace_locations
       end
 
-      # Multiplies +value+ recursively by +scalar+, traversing through Hashes
-      # and Arrays.
+      # Computes a nested sum of +values+ weighted by +weights+, each of which
+      # must be an Array of the same length.  Each individual element in
+      # +values+ may be a complex structure of Hashes and Arrays.  Returns the
+      # weighted sum of the values.
       #
-      # Used by #multi_blend for weighted interpolation.
-      #
-      def deep_multiply(value, scalar)
-        deep_math(value, scalar, operation: :*)
-      end
+      # If the +weights+ add up to 1.0, then this computes the weighted average
+      # of the +values+.
+      def weighted_sum(values, weights)
+        unless values.is_a?(Array) && weights.is_a?(Array) && values.length == weights.length
+          raise 'Values and weights must be Arrays of the same length'
+        end
 
-      def multi_blend(values, weights, func: nil)
-        very_deep_math(values, weights, operation: :*)
+        very_deep_math(values, :*, weights).reduce { |a, b| very_deep_math(a, :+, b) }
       end
 
       # Returns the value at +blend+ (from 0 to 1) of a Catmull-Rom spline

--- a/lib/mb/m/interpolation_methods.rb
+++ b/lib/mb/m/interpolation_methods.rb
@@ -125,7 +125,7 @@ module MB
         end
       rescue => e
         raise if e.message.start_with?('Error at')
-        raise e.class, "#{path_string(path, prefix: 'Error at ')}: #{e.message}", e.backtrace_locations
+        raise e.class, "#{path_string(path, prefix: 'Error at ')}: #{e.message}", e.backtrace
       end
 
       # Recursively applies +:operation+ between the two matching elements in
@@ -166,7 +166,7 @@ module MB
 
       rescue => e
         raise if e.message.start_with?('Error at')
-        raise e.class, "#{path_string(path, prefix: 'Error at ')}: #{e.message}", e.backtrace_locations
+        raise e.class, "#{path_string(path, prefix: 'Error at ')}: #{e.message}", e.backtrace
       end
 
       # Computes a nested sum of +values+ weighted by +weights+, each of which

--- a/lib/mb/m/version.rb
+++ b/lib/mb/m/version.rb
@@ -1,5 +1,5 @@
 module MB
   module M
-    VERSION = "0.2.2.usegit"
+    VERSION = "0.2.3.usegit"
   end
 end

--- a/spec/lib/mb/m/interpolation_methods_spec.rb
+++ b/spec/lib/mb/m/interpolation_methods_spec.rb
@@ -162,6 +162,50 @@ RSpec.describe(MB::M::InterpolationMethods) do
     end
   end
 
+  describe '#deep_math' do
+    context 'with operation: :*' do
+      it 'can multiply Strings just because it was more work to avoid it' do
+        expect(MB::M.deep_math(['a', {b: 'c'}], 3, operation: :*)).to eq(['aaa', {b: 'ccc'}])
+      end
+    end
+
+    it 'handles cycles in the data graph' do
+      a = {a: 1, b: 2, c: {d: nil}}
+      a[:c][:d] = a
+
+      expected = {a: 2, b: 3, c: {d: nil}}
+
+      result = MB::M.deep_math(a, 1, operation: :+)
+      recursed = result[:c][:d]
+      expect(recursed[:a]).to eq(2)
+      expect(recursed.__id__).to eq(result.__id__)
+
+      # RSpec eq() seems not to handle cycles in data structures
+      result[:c][:d] = nil
+      expect(result).to eq(expected)
+    end
+
+    pending 'with Numo::NArray'
+
+    pending 'can add numbers'
+    pending 'can multiply numbers'
+    pending 'can subtract numbers'
+    pending 'can divide numbers'
+    pending 'can exponentiate numbers'
+
+    pending
+  end
+
+  describe '#very_deep_math' do
+    context 'with operation: :*' do
+      it 'can multiply Strings with Integers' do
+        expect(MB::M.very_deep_math(['q', {a: 'a', b: 'bc'}], [2, {a: 3, b: 2}], operation: :*)).to eq(['qq', {a: 'aaa', b: 'bcbc'}])
+      end
+    end
+
+    pending 'raises an error for cycles in the data graph'
+  end
+
   describe '#catmull_rom' do
     it 'can interpolate numeric values' do
       expect(MB::M.catmull_rom(1, 5, 15, 3, 0.5)).to be_between(10, 12)

--- a/spec/lib/mb/m/interpolation_methods_spec.rb
+++ b/spec/lib/mb/m/interpolation_methods_spec.rb
@@ -230,7 +230,17 @@ RSpec.describe(MB::M::InterpolationMethods) do
       expect(MB::M.very_deep_math({1 => 2}, :+, {1 => 4})).to eq({1 => 6})
     end
 
-    pending 'with Numo::NArray'
+    it 'can apply an operator to two Numo::NArrays' do
+      expect(MB::M.very_deep_math({a: Numo::SFloat[-1, 2, 3]}, :**, {a: Numo::SFloat[3, 3, 2]})).to eq({a: Numo::SFloat[-1, 8, 9]})
+    end
+
+    it 'can apply a scalar to a Numo::NArray' do
+      expect(MB::M.very_deep_math({a: Numo::SFloat[-1, 2, 3]}, :**, {a: 2})).to eq({a: Numo::SFloat[1, 4, 9]})
+    end
+
+    it 'can apply a Numo::NArray to a scalar' do
+      expect(MB::M.very_deep_math({a: 2}, :**, {a: Numo::SFloat[2, 3, 16]})).to eq({a: Numo::SFloat[4, 8, 65536]})
+    end
 
     it 'can add numbers' do
       expect(MB::M.very_deep_math(1, :+, 2)).to eq(3)

--- a/spec/lib/mb/m/interpolation_methods_spec.rb
+++ b/spec/lib/mb/m/interpolation_methods_spec.rb
@@ -215,6 +215,14 @@ RSpec.describe(MB::M::InterpolationMethods) do
     it 'can exponentiate numbers' do
       expect(MB::M.deep_math(Math::E, :**, 1i * Math::PI)).to eq(-1)
     end
+
+    it 'raises an error if given an unsupported operation' do
+      expect { MB::M.deep_math(16, :^, 2) }.to raise_error(ArgumentError, /Error at.*Unknown operation :\^/)
+    end
+
+    it 'raises an error if given incompatible data types' do
+      expect { MB::M.deep_math(5, :*, 'invalid') }.to raise_error(TypeError, /Error at root/)
+    end
   end
 
   describe '#very_deep_math' do

--- a/spec/lib/mb/m/polynomial_spec.rb
+++ b/spec/lib/mb/m/polynomial_spec.rb
@@ -671,7 +671,7 @@ RSpec.describe(MB::M::Polynomial, :aggregate_failures) do
 
     it 'can find random integer roots' do
       100.times do
-        p, roots, scale = MB::M::Polynomial.random_roots(7, range: -10..10)
+        p, roots, _scale = MB::M::Polynomial.random_roots(7, range: -10..10)
         expect(MB::M.convert_down(MB::M.round(p.roots, 4)).sort).to eq(roots.sort)
       end
     end

--- a/spec/lib/mb/m/precision_methods_spec.rb
+++ b/spec/lib/mb/m/precision_methods_spec.rb
@@ -75,6 +75,10 @@ RSpec.describe(MB::M::PrecisionMethods) do
       it 'rounds NArrays' do
         expect(MB::M.round(Numo::SFloat[-3.4, -2.9, -2.1, 0.4, 1.5])).to eq([-3, -3, -2, 0, 2])
       end
+
+      it 'rounds Hashes' do
+        expect(MB::M.round({a: 1.2, b: [2.1, 3.9]})).to eq({a: 1, b: [2, 4]})
+      end
     end
 
     context 'with positive figs' do
@@ -97,6 +101,10 @@ RSpec.describe(MB::M::PrecisionMethods) do
         expect(MB::M.round(Numo::SFloat[-0.00125, 1.23456], 4)).to eq([-0.0013, 1.2346])
         expect(MB::M.round(Numo::SFloat[-0.00125, 1.23456], 7)).to eq([-0.00125, 1.23456])
       end
+
+      it 'rounds Hashes' do
+        expect(MB::M.round({a: 0.00125, b: [1.23456, 6.11111111]}, 4)).to eq({a: 0.0013, b: [1.2346, 6.1111]})
+      end
     end
 
     context 'with negative figs' do
@@ -115,6 +123,10 @@ RSpec.describe(MB::M::PrecisionMethods) do
       it 'rounds NArrays' do
         expect(MB::M.round(Numo::SFloat[12345.6789, -543], -1)).to eq(Numo::SFloat[12350, -540])
         expect(MB::M.round(Numo::SFloat[12345.6789, -543], -4)).to eq(Numo::SFloat[10000, 0])
+      end
+
+      it 'rounds Hashes' do
+        expect(MB::M.round({a: 12345.67, b: [-543, 543]}, -2)).to eq({a: 12300, b: [-500, 500]})
       end
     end
 
@@ -138,6 +150,10 @@ RSpec.describe(MB::M::PrecisionMethods) do
 
       it 'rounds real and imaginary parts separately' do
         expect(MB::M.round(1.23456-0.00789i, 3)).to eq(1.235-0.008i)
+      end
+
+      it 'rounds Complex numbers within a Hash' do
+        expect(MB::M.round({a: [1.25i, 1.75i], b: 3.95 + 3.0005i}, 1)).to eq({a: [1.3i, 1.8i], b: 4+3i})
       end
     end
   end


### PR DESCRIPTION
This PR adds the ability to do weighted sums and other simple arithmetic across nested numeric values within `Hash`es and `Array`s.

For example:

```ruby
MB::M.very_deep_math({a: [1, 2], b: 3}, :+, {a: [5, 7], b: -1})
=> {a: [6, 9], b: 2}

MB::M.weighted_sum([{data: [1, 2]}, {data: [3, 4]}], [0.5, 1])
=> {data: [3.5, 5.0]}
```

This is useful for interpolation across multiple dimensions and datapoints, such as with natural neighbor interpolation of multiple measurement sets taken at Voronoi cell locations.