### PR TITLE
Sigfigs matcher

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 PATH
   remote: .
   specs:
-    mb-math (0.2.5.2.usegit)
+    mb-math (0.2.6.usegit)
       bigdecimal (~> 3.1.8)
       cmath (~> 1.0.0)
       matrix (~> 0.4.2)

--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ runs tests automatically.
 `Numo::NArray`:
 
 - Approximate element-by-element equality: `all_be_within(max_delta).of_array(other)`
+- Approximate element-by-element sigfigs equality: `all_be_within(max_delta).sigfigs.of_array(other)`
 
 To use these matchers, `requre 'mb/m/rspec_matchers'` to your `spec_helper.rb`
 file:

--- a/lib/mb/m/rspec_matchers.rb
+++ b/lib/mb/m/rspec_matchers.rb
@@ -6,8 +6,13 @@ require 'rspec/expectations'
 # same size, failing if any pair of elements has an absolute value difference
 # greater than or equal to +max_delta+.
 #
+# If .sigfigs is added before .of_array, then the delta given will be treated
+# as a number of digits, and the log10 is compared instead.  This is useful for
+# comparing floating point values of unknown magnitudes.  The difference is
+# given in number of matching digits when in sigfigs mode.
+#
 # Example:
-#     expect(Numo::SFloat[1,2,3]).to all_be_within([
+#     expect(Numo::SFloat[1,2,3]).to all_be_within(3).of_array([0, 1, 2])
 RSpec::Matchers.define :all_be_within do |max_delta|
   match do |actual|
     @max_delta = max_delta
@@ -35,18 +40,51 @@ RSpec::Matchers.define :all_be_within do |max_delta|
       next false
     end
 
-    diff = na_actual - na_expected
+    next true if na_actual.length == 0
+
+    if @sigfigs
+      puts 'sigfigs diff'
+      diff = na_actual.map_with_index { |v, idx|
+        v2 = na_expected[idx]
+
+        inputs = [v.abs, v2.abs]
+        inputs += [v.real.abs, v.imag.abs] if v.respond_to?(:real)
+        inputs += [v2.real.abs, v2.imag.abs] if v2.respond_to?(:real)
+
+        if inputs.max == 0
+          scale = 0
+        else
+          # Subtracting log10(0.5) to get within +/- 5 at the target digit
+          scale = Math.log10(inputs.max) - Math.log10(0.5)
+        end
+
+        d = (v - v2).abs
+
+        d == 0 ? Float::INFINITY : scale - Math.log10(d)
+      }
+
+      absdiff = diff.abs
+      idx = absdiff.max_index
+      delta = absdiff.min
+      idx = absdiff.min_index
+      failure = delta < max_delta
+    else
+      puts 'normal diff'
+      diff = na_actual - na_expected
+      absdiff = diff.abs
+      delta = absdiff.max
+      idx = absdiff.max_index
+      failure = delta > max_delta
+    end
+
+    puts "failure=#{failure} delta=#{delta} max_delta=#{max_delta} absdiff=#{absdiff}"
 
     if diff.respond_to?(:isnan) && diff.isnan.count_1 != 0
       @msg = 'some elements of either array were NaN (not a number)'
       next false
     end
 
-    absdiff = diff.abs
-
-    delta = absdiff.max
-    if delta > max_delta
-      idx = absdiff.max_index
+    if failure
       expected_at_idx = na_expected.is_a?(Numeric) ? na_expected : na_expected[idx]
       actual_at_idx = na_actual[idx]
 
@@ -58,12 +96,17 @@ RSpec::Matchers.define :all_be_within do |max_delta|
     true
   end
 
+  chain :sigfigs do
+    @sigfigs = true
+  end
+
   chain :of_array do |expected|
     @expected = expected
   end
 
   failure_message do
-    "expected all elements of #{actual} to be within #{@max_delta} of #{@expected}, but #{@msg}\n#{super()}"
+    puts "expected all elements of #{actual} to be within #{@max_delta}#{' significant figures' if @sigfigs} of #{@expected}, but #{@msg}\n#{super()}"
+    "expected all elements of #{actual} to be within #{@max_delta}#{' significant figures' if @sigfigs} of #{@expected}, but #{@msg}\n#{super()}"
   end
 
   # FIXME: is this even doing anything?

--- a/lib/mb/m/rspec_matchers.rb
+++ b/lib/mb/m/rspec_matchers.rb
@@ -101,9 +101,9 @@ RSpec::Matchers.define :all_be_within do |max_delta|
 
   failure_message do
     if @sigfigs
-      "expected all elements of #{actual.inspect} to match at least #{@max_delta} significant figures of #{@expected.inspect}, but #{@msg}\n#{super()}"
+      "expected all elements of #{actual.inspect} to match at least #{@max_delta} significant figures of #{@expected.inspect}, but #{@msg}"
     else
-      "expected all elements of #{actual.inspect} to be within #{@max_delta} of #{@expected.inspect}, but #{@msg}\n#{super()}"
+      "expected all elements of #{actual.inspect} to be within #{@max_delta} of #{@expected.inspect}, but #{@msg}"
     end
   end
 

--- a/lib/mb/m/version.rb
+++ b/lib/mb/m/version.rb
@@ -1,5 +1,5 @@
 module MB
   module M
-    VERSION = "0.2.5.2.usegit"
+    VERSION = "0.2.6.usegit"
   end
 end

--- a/spec/lib/mb/m/rspec_matchers_spec.rb
+++ b/spec/lib/mb/m/rspec_matchers_spec.rb
@@ -92,7 +92,15 @@ RSpec.describe('mb-math RSpec matchers', aggregate_failures: false) do
         }.not_to raise_error
 
         expect {
-          expect(Numo::SFloat[12345]).to all_be_within(4).sigfigs.of_array(Numo::SFloat[12347])
+          expect(Numo::SFloat[12347]).to all_be_within(4).sigfigs.of_array(Numo::SFloat[12345])
+        }.not_to raise_error
+
+        expect {
+          expect([12357]).to all_be_within(4).sigfigs.of_array([12345])
+        }.not_to raise_error
+
+        expect {
+          expect(Numo::SFloat[100010]).to all_be_within(5).sigfigs.of_array(Numo::SFloat[100000])
         }.not_to raise_error
       end
 
@@ -102,15 +110,15 @@ RSpec.describe('mb-math RSpec matchers', aggregate_failures: false) do
         }.to raise_error(RSpec::Expectations::ExpectationNotMetError, /3 significant figures/)
 
         expect {
-          expect(Numo::SFloat[12345]).to all_be_within(4).sigfigs.of_array(Numo::SFloat[12348])
+          expect(Numo::SFloat[12345]).to all_be_within(4).sigfigs.of_array(Numo::SFloat[12357.4])
         }.to raise_error(RSpec::Expectations::ExpectationNotMetError, /4 significant figures/)
 
         expect {
-          expect(Numo::SFloat[99995]).to all_be_within(5).sigfigs.of_array(Numo::SFloat[99989])
+          expect(Numo::SFloat[100011]).to all_be_within(5).sigfigs.of_array(Numo::SFloat[100000])
         }.to raise_error(RSpec::Expectations::ExpectationNotMetError, /5 significant figures/)
 
         expect {
-          expect(Numo::SFloat[12345, 12346]).to all_be_within(5).sigfigs.of_array(Numo::SFloat[12349, 12340])
+          expect(Numo::SFloat[12358]).to all_be_within(4).sigfigs.of_array(Numo::SFloat[12345])
         }.to raise_error
       end
 

--- a/spec/lib/mb/m/rspec_matchers_spec.rb
+++ b/spec/lib/mb/m/rspec_matchers_spec.rb
@@ -75,5 +75,50 @@ RSpec.describe('mb-math RSpec matchers', aggregate_failures: false) do
         expect([1, 2]).to all_be_within(1).of_array(1)
       }.not_to raise_error
     end
+
+    it 'can compare empty arrays' do
+      expect {
+        expect([]).to all_be_within(0).of_array([])
+      }.not_to raise_error
+      expect {
+        expect(Numo::SFloat[]).to all_be_within(0).of_array(Numo::DComplex[])
+      }.not_to raise_error
+    end
+
+    describe '.sigfigs' do
+      it 'compares leading digits instead of absolute differences for a match' do
+        expect {
+          expect(Numo::SComplex[0.00101i, 0.00201]).to all_be_within(2).sigfigs.of_array(Numo::SComplex[0.001i, 0.002])
+        }.not_to raise_error
+
+        expect {
+          expect(Numo::SFloat[12345]).to all_be_within(4).sigfigs.of_array(Numo::SFloat[12347])
+        }.not_to raise_error
+      end
+
+      it 'includes the significant figures in the message for a non-match' do
+        expect {
+          expect(Numo::SComplex[0.001i, 0.002 + 0.002i]).to all_be_within(3).sigfigs.of_array(Numo::SFloat[1, 1])
+        }.to raise_error(RSpec::Expectations::ExpectationNotMetError, /3 significant figures/)
+
+        expect {
+          expect(Numo::SFloat[12345]).to all_be_within(4).sigfigs.of_array(Numo::SFloat[12348])
+        }.to raise_error(RSpec::Expectations::ExpectationNotMetError, /4 significant figures/)
+
+        expect {
+          expect(Numo::SFloat[99995]).to all_be_within(5).sigfigs.of_array(Numo::SFloat[99989])
+        }.to raise_error(RSpec::Expectations::ExpectationNotMetError, /5 significant figures/)
+
+        expect {
+          expect(Numo::SFloat[12345, 12346]).to all_be_within(5).sigfigs.of_array(Numo::SFloat[12349, 12340])
+        }.to raise_error
+      end
+
+      it 'can compare zero to zero' do
+        expect {
+          expect(Numo::SComplex[0]).to all_be_within(2).sigfigs.of_array(Numo::SFloat[0])
+        }.not_to raise_error
+      end
+    end
   end
 end

--- a/spec/lib/mb/m/rspec_matchers_spec.rb
+++ b/spec/lib/mb/m/rspec_matchers_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe('mb-math RSpec matchers', aggregate_failures: false) do
 
         expect {
           expect(Numo::SFloat[12358]).to all_be_within(4).sigfigs.of_array(Numo::SFloat[12345])
-        }.to raise_error
+        }.to raise_error(RSpec::Expectations::ExpectationNotMetError, /4 significant figures/)
       end
 
       it 'can compare zero to zero' do


### PR DESCRIPTION
Added a custom RSpec matcher to compare arrays up to a given factor of 10 / given number of digits.

E.g. 10010 will be within 4 sigfigs of 10000 but 10011 will not.

This was developed for https://github.com/mike-bourgeous/mb-sound/pull/42