### PR TITLE
Add an rtrim method for Numo::NArray and Array trimming.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 PATH
   remote: .
   specs:
-    mb-math (0.2.7.2.usegit)
+    mb-math (0.2.8.usegit)
       bigdecimal (~> 3.1.8)
       cmath (~> 1.0.0)
       matrix (~> 0.4.2)

--- a/lib/mb/m/array_methods.rb
+++ b/lib/mb/m/array_methods.rb
@@ -312,6 +312,17 @@ module MB
       end
       alias skip_trailing rtrim
 
+      # Equivalent to both rtrim and ltrim together.  Calls ltrim first, then
+      # rtrim.
+      def trim(array, value = 0)
+        if block_given?
+          a = ltrim(array) do |v| yield v end
+          rtrim(a) do |v| yield v end
+        else
+          rtrim(ltrim(array, value), value)
+        end
+      end
+
       # Rotates a 1D NArray left by +n+ places, which must be less than the
       # length of the NArray.  Returns a duplicate of the original array if +n+
       # is zero or the rotation would have no effect.  Use negative values for

--- a/lib/mb/m/array_methods.rb
+++ b/lib/mb/m/array_methods.rb
@@ -218,9 +218,9 @@ module MB
         pad(narray, min_length, value: 1, alignment: alignment, &bl)
       end
 
-      # Returns a new Array or Numo::NArray with leading copies of +value+
-      # removed from the given +array+.  Returns an empty array if the array is
-      # entirely equal to +value+.
+      # Returns a new Array or a Numo::NArray view with leading copies of
+      # +value+ removed from the given +array+.  Returns an empty array if the
+      # array is entirely equal to +value+.
       #
       # For Ruby Arrays, this just calls Array#drop_while.  The method is
       # provided mainly for use with Numo::NArray.
@@ -273,6 +273,44 @@ module MB
         end
       end
       alias skip_leading ltrim
+
+      # Returns a new Array or a Numo::NArray view with trailing copies of
+      # +value+ removed from the +array+.  Returns an empty array if the array
+      # is entirely equal to +value+.
+      #
+      # If a block is given, then instead of using +value+, array elements are
+      # removed from the end as long as the block returns true when yielded the
+      # element.  Returns an empty array if the block always returns true.
+      def rtrim(array, value = 0)
+        case array
+        when Numo::NArray, Array
+          idx = nil
+
+          if block_given?
+            for i in (-1..-array.length).step(-1)
+              unless yield array[i]
+                idx = i
+                break
+              end
+            end
+          else
+            for i in (-1..-array.length).step(-1)
+              unless array[i] == value
+                idx = i
+                break
+              end
+            end
+          end
+
+          return array.class[] if idx.nil?
+
+          array[0..idx]
+
+        else
+          raise ArgumentError, "Expecting Numo::NArray or Array, got #{array.class}"
+        end
+      end
+      alias skip_trailing rtrim
 
       # Rotates a 1D NArray left by +n+ places, which must be less than the
       # length of the NArray.  Returns a duplicate of the original array if +n+

--- a/lib/mb/m/version.rb
+++ b/lib/mb/m/version.rb
@@ -1,5 +1,5 @@
 module MB
   module M
-    VERSION = "0.2.7.2.usegit"
+    VERSION = "0.2.8.usegit"
   end
 end

--- a/spec/lib/mb/m/array_methods_spec.rb
+++ b/spec/lib/mb/m/array_methods_spec.rb
@@ -463,10 +463,6 @@ RSpec.describe(MB::M::ArrayMethods, :aggregate_failures) do
       it 'returns an empty array if given a block and all values match' do
         expect(MB::M.rtrim(Numo::SFloat.ones(6)) { true }).to eq(Numo::SFloat[])
       end
-
-      it 'raises an error if given a different type' do
-        expect { MB::M.rtrim({}) }.to raise_error(ArgumentError, /Expecting.*got.*Hash/)
-      end
     end
 
     context 'with Array' do
@@ -510,7 +506,53 @@ RSpec.describe(MB::M::ArrayMethods, :aggregate_failures) do
     end
 
     it 'raises an error for a non-array type' do
-      expect { MB::M.rtrim('hello', 'h') }.to raise_error(ArgumentError, /array/i)
+      expect { MB::M.rtrim({}) }.to raise_error(ArgumentError, /Expecting.*got.*Hash/)
+      expect { MB::M.rtrim('hello', 'h') }.to raise_error(ArgumentError, /array.*String/i)
+    end
+  end
+
+  describe '.trim' do
+    it 'can remove leading values' do
+      expect(MB::M.trim([0, 1, 2, 3])).to eq([1, 2, 3])
+      expect(MB::M.trim(Numo::DFloat[0, 1, 2, 3])).to eq(Numo::DFloat[1, 2, 3])
+    end
+
+    it 'can remove trailing values' do
+      expect(MB::M.trim([0, 1, 2, 3])).to eq([1, 2, 3])
+      expect(MB::M.trim(Numo::DFloat[0, 1, 2, 3])).to eq(Numo::DFloat[1, 2, 3])
+    end
+
+    it 'can remove values on both ends' do
+      expect(MB::M.trim([1, 0, 1], 1)).to eq([0])
+      expect(MB::M.trim(Numo::Int32[1, 0, 1], 1)).to eq(Numo::Int32[0])
+    end
+
+    it 'can use a block to reject values' do
+      expect(MB::M.trim([0, 1, 2, 3, 4], &:even?)).to eq([1, 2, 3])
+      expect(MB::M.trim(Numo::Int32[0, 1, 2, 3, 4], &:even?)).to eq(Numo::Int32[1, 2, 3])
+
+      expect(MB::M.trim([0, 1, 2, 3, 4], &:odd?)).to eq([0, 1, 2, 3, 4])
+      expect(MB::M.trim(Numo::Int32[0, 1, 2, 3, 4], &:odd?)).to eq(Numo::Int32[0, 1, 2, 3, 4])
+    end
+
+    it 'returns an empty array for an empty array' do
+      expect(MB::M.trim([])).to eq([])
+      expect(MB::M.trim(Numo::SFloat[])).to eq(Numo::SFloat[])
+    end
+
+    it 'returns an empty array if all values are removed' do
+      expect(MB::M.trim([2, 2, 2], 2)).to eq([])
+      expect(MB::M.trim(Numo::Int64[2, 2, 2], 2)).to eq(Numo::Int64[])
+    end
+
+    it 'returns an empty array if all values are removed by a block' do
+      expect(MB::M.trim([2, 4, 6], &:even?)).to eq([])
+      expect(MB::M.trim(Numo::DComplex[2, 4, 6]) { true }).to eq(Numo::DComplex[])
+    end
+
+    it 'raises an error for a non-array type' do
+      expect { MB::M.trim({}) }.to raise_error(ArgumentError, /Expecting.*got.*Hash/)
+      expect { MB::M.trim('hello', 'h') }.to raise_error(ArgumentError, /array.*String/i)
     end
   end
 

--- a/spec/lib/mb/m/array_methods_spec.rb
+++ b/spec/lib/mb/m/array_methods_spec.rb
@@ -427,6 +427,93 @@ RSpec.describe(MB::M::ArrayMethods, :aggregate_failures) do
     end
   end
 
+  describe '#rtrim' do
+    context 'with Numo::NArray' do
+      let(:zero) { Numo::SFloat[1, 2, 3, 0, 0, 0] }
+      let(:one) { Numo::SFloat[2, 3, 4, 1, 1, 1] }
+
+      it 'returns an empty array for an empty array' do
+        expect(MB::M.rtrim(Numo::SFloat[])).to eq(Numo::SFloat[])
+      end
+
+      it 'accepts a value parameter' do
+        expect(MB::M.rtrim(zero, 1)).to eq(zero)
+        expect(MB::M.rtrim(zero, 0)).to eq(Numo::SFloat[1, 2, 3])
+
+        expect(MB::M.rtrim(one, 0)).to eq(one)
+        expect(MB::M.rtrim(one, 1)).to eq(Numo::SFloat[2, 3, 4])
+      end
+
+      it 'accepts a block' do
+        expect(MB::M.rtrim(Numo::Int32[1, 3, 5, 2, 4, 6], 1, &:even?)).to eq([1, 3, 5])
+        expect(MB::M.rtrim(Numo::Int32[1, 3, 5, 2, 4, 6], 1, &:odd?)).to eq([1, 3, 5, 2, 4, 6])
+        expect(MB::M.rtrim(Numo::SFloat[2, 4, 6, Float::NAN, Float::INFINITY, -Float::INFINITY]) { |v| !v.finite? }).to eq(Numo::SFloat[2, 4, 6])
+      end
+
+      it 'returns an empty array if all values match' do
+        expect(MB::M.rtrim(Numo::SFloat.zeros(6))).to eq(Numo::SFloat[])
+        expect(MB::M.rtrim(Numo::SFloat.ones(6), 1)).to eq(Numo::SFloat[])
+      end
+
+      it 'returns the same type' do
+        expect(MB::M.rtrim(Numo::SFloat[0,1,2])).to be_a(Numo::SFloat)
+        expect(MB::M.rtrim(Numo::Int32[0,1,2])).to be_a(Numo::Int32)
+      end
+
+      it 'returns an empty array if given a block and all values match' do
+        expect(MB::M.rtrim(Numo::SFloat.ones(6)) { true }).to eq(Numo::SFloat[])
+      end
+
+      it 'raises an error if given a different type' do
+        expect { MB::M.rtrim({}) }.to raise_error(ArgumentError, /Expecting.*got.*Hash/)
+      end
+    end
+
+    context 'with Array' do
+      let(:zero) { [1, 2, 3, 0, 0, 0] }
+      let(:one) { [2, 3, 4, 1, 1, 1] }
+
+      it 'returns an empty array for an empty array' do
+        expect(MB::M.rtrim([])).to eq([])
+      end
+
+      it 'accepts a value parameter' do
+        expect(MB::M.rtrim(zero, 1)).to eq(zero)
+        expect(MB::M.rtrim(zero, 0)).to eq([1, 2, 3])
+
+        expect(MB::M.rtrim(one, 0)).to eq(one)
+        expect(MB::M.rtrim(one, 1)).to eq([2, 3, 4])
+      end
+
+      it 'accepts a block' do
+        expect(MB::M.rtrim([1, 3, 5, 2, 4, 6], 1, &:even?)).to eq([1, 3, 5])
+        expect(MB::M.rtrim([1, 3, 5, 2, 4, 6], 1, &:odd?)).to eq([1, 3, 5, 2, 4, 6])
+        expect(MB::M.rtrim([2, 4, 6, Float::NAN, Float::INFINITY, -Float::INFINITY]) { |v| !v.finite? }).to eq([2, 4, 6])
+      end
+
+      it 'returns an empty array if all values match' do
+        expect(MB::M.rtrim([0] * 6)).to eq([])
+        expect(MB::M.rtrim([1] * 6, 1)).to eq([])
+      end
+
+      it 'does not have to use numbers in a Ruby Array' do
+        expect(MB::M.rtrim(['a', 'b', '', ''], '')).to eq(['a', 'b'])
+      end
+
+      it 'returns an empty array if given a block and all values match' do
+        expect(MB::M.rtrim([1, 2, 3, 4, 5, 6]) { true }).to eq([])
+      end
+    end
+
+    it 'is aliased to skip_trailing' do
+      expect(MB::M.skip_trailing([1, 2, 0, 0])).to eq([1, 2])
+    end
+
+    it 'raises an error for a non-array type' do
+      expect { MB::M.rtrim('hello', 'h') }.to raise_error(ArgumentError, /array/i)
+    end
+  end
+
   describe '.rol' do
     context 'with Numo::NArray' do
       it 'returns the same array with a rotation of 0' do


### PR DESCRIPTION
This PR adds `MB::M.rtrim()` and `MB::M.trim()` for removing matching values from the end or both start and end of `Array` and `Numo::NArray`.

There was already an `ltrim` method.  The `rtrim` version will help with testing processes that return arrays that might have trailing padding of unknown length.