### PR TITLE
Add support for 3D surface plots

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 PATH
   remote: .
   specs:
-    mb-math (0.2.8.usegit)
+    mb-math (0.3.0.usegit)
       bigdecimal (~> 3.1.8)
       cmath (~> 1.0.0)
       matrix (~> 0.4.2)

--- a/lib/mb/m/plot.rb
+++ b/lib/mb/m/plot.rb
@@ -406,14 +406,14 @@ module MB
       end
 
       def print_terminal_plot(print)
-        buf = read.reject { |l| l.empty? || l.include?('plot>') || l.strip.start_with?(/[[:alpha:]]/) }
-        start_index = buf.index { |l| l.include?('+----') }
+        buf = read.reject { |l| l.strip.empty? || l.include?('plot>') || (l.strip.start_with?(/[[:alpha:]]/) && !l.match?(/[-+*]{3,}/)) }
+        start_index = buf.index { |l| l.include?('+----') || l.include?('*') }
         lines = buf[start_index..-1]
 
         row = 0
         in_graph = false
         lines.map!.with_index { |l, idx|
-          if l.include?('+----')
+          if l.match?(/\+-{10,}\+/)
             if in_graph
               in_graph = false
               row += 1
@@ -523,7 +523,7 @@ module MB
           else
             array.each_with_index do |z, y, x|
               if y != last_y
-                # Break apart rows to give a waterfall-type plot
+                # Break apart rows to give a waterfall-type plot when type is lines
                 file.puts if type == 'lines'
                 file.puts
               end

--- a/lib/mb/m/plot.rb
+++ b/lib/mb/m/plot.rb
@@ -416,7 +416,8 @@ module MB
       def print_terminal_plot(print)
         buf = read.drop_while { |l| l.include?('plot>') || (l.strip.start_with?(/[[:alpha:]]/) && !l.match?(/[-+*]{3,}/)) }[0..-2]
         start_index = buf.rindex { |l| l.include?('plot>') }
-        raise "Error: no plot was found within #{buf}" unless start_index
+        raise "Error: no plot was found within #{buf}" unless buf.count > 3 || start_index
+        start_index ||= 0
         lines = buf[(start_index + 2)..-1]
 
         row = 0

--- a/lib/mb/m/plot.rb
+++ b/lib/mb/m/plot.rb
@@ -29,8 +29,8 @@ module MB
     #     p = MB::M::Plot.graphical
     #     p.type = 'pm3d' # or lines or surface
     #
-    #     a = Numo::SFloat[Numo::SFloat.linspace(1, 5, 30).map { |v| Math.sin(v) * 3 }] * \
-    #       Numo::SFloat[Numo::SFloat.linspace(-10, 10, 30).map { |v| Math.sin(v / 2) * 7 }].transpose
+    #     a = Numo::SFloat.linspace(1, 5, 30).map { |v| Math.sin(v) * 3 }.reshape(1, nil) * \
+    #       Numo::SFloat.linspace(-10, 10, 30).map { |v| Math.sin(v / 2) * 7 }.reshape(nil, 1)
     #
     #     p.plot({wavy: {data: a, zrange: [-30, 30]}})
     #

--- a/lib/mb/m/version.rb
+++ b/lib/mb/m/version.rb
@@ -1,5 +1,5 @@
 module MB
   module M
-    VERSION = "0.2.8.usegit"
+    VERSION = "0.3.0.usegit"
   end
 end

--- a/spec/lib/mb/m/plot_spec.rb
+++ b/spec/lib/mb/m/plot_spec.rb
@@ -154,5 +154,7 @@ RSpec.describe MB::M::Plot do
         end
       end
     end
+
+    pending '3D plots'
   end
 end

--- a/spec/lib/mb/m/plot_spec.rb
+++ b/spec/lib/mb/m/plot_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe MB::M::Plot do
   end
 
   describe '#plot' do
+    let(:plot) { MB::M::Plot.terminal(width: 80, height: 50) }
     let(:data) { {test123: [1, 0, 0, 0, 0], data321: [1, 0, 1, 0, 0, 0]} }
-
     let(:scatter) {
       {
         scatter123: [
@@ -38,8 +38,6 @@ RSpec.describe MB::M::Plot do
     }
 
     context 'with the dumb terminal type' do
-      let(:plot) { MB::M::Plot.terminal(width: 80, height: 50) }
-
       it 'can plot to an array of lines' do
         begin
           lines = plot.plot(data, print: false)
@@ -132,6 +130,15 @@ RSpec.describe MB::M::Plot do
       plot = MB::M::Plot.terminal(width: 80, height: 80, height_fraction: 1)
       lines = plot.plot({data: Numo::SFloat[10, -10, 10, -10, 10]}, print: false)
       expect(lines.count).to eq(80)
+    end
+
+    it 'raises an error when given something other than a Hash' do
+      expect { plot.plot([1,2,3]) }.to raise_error(ArgumentError, /hash/i)
+    end
+
+    it 'raises an error when a data element is not an Array or Numo::NArray' do
+      expect { plot.plot({a: {data: nil}}) }.to raise_error(ArgumentError, /nil.*array/i)
+      expect { plot.plot({a: "1, 2, 3"}) }.to raise_error(ArgumentError, /string.*array/i)
     end
 
     context '3D plots' do


### PR DESCRIPTION
This adds support for plotting a 2D Numo::NArray as a waterfall-like stacked line plot, a surface grid plot, a pm3d plot, or a fence plot.

```ruby
a = Numo::SFloat.linspace(-10, 10, 30).map { |v| Math.sin(v) * 3 }.reshape(1, nil) * Numo::SFloat.linspace(-5, 5, 2).reshape(nil, 1)
p = MB::M::Plot.terminal
p.plot({plot_test: a})
```

<img width="2265" height="650" alt="image" src="https://github.com/user-attachments/assets/cb0a6a27-d248-45e0-948b-350b65a120e8" />

```ruby
a = Numo::SFloat.linspace(-10, 10, 30).map { |v| Math.sin(v / 3) * 3 }.reshape(1, nil) * Numo::SFloat.linspace(-5, 5, 30).map { |v| Math.cos(v / 2) }.reshape(nil, 1)
p = MB::M::Plot.graphical(width: 1024, height: 768)

# Solid surface
p.type = 'pm3d'
p.plot({plot_test: a})

# Stacked lines
p.type = 'lines'
p.plot({plot_test: a})

# Fence
p.type = 'zerrorfill'
p.command 'set style fill transparent solid 0.5'
p.plot({plot_test: a + 5})
```

<img width="1023" height="766" alt="image" src="https://github.com/user-attachments/assets/1428a181-ac4e-436f-8e87-5b01eb544926" />

<img width="1023" height="766" alt="image" src="https://github.com/user-attachments/assets/808593f0-afd7-497e-9f0f-b1b0314b89eb" />

<img width="1023" height="766" alt="image" src="https://github.com/user-attachments/assets/a7a74a6c-8928-4ae5-ae98-ef7987cec734" />
