### PR TITLE
Wavetable prereqs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install apt deps
         run: |
           sudo apt-get update
-          sudo apt-get install ffmpeg gnuplot-nox
+          sudo apt-get install ffmpeg gnuplot-qt
       - name: Install gem deps
         run: bundle install
       - name: Run RSpec tests

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 PATH
   remote: .
   specs:
-    mb-math (0.3.1.usegit)
+    mb-math (0.4.0.usegit)
       bigdecimal (~> 3.1.8)
       cmath (~> 1.0.0)
       matrix (~> 0.4.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 PATH
   remote: .
   specs:
-    mb-math (0.3.0.2.usegit)
+    mb-math (0.3.1.usegit)
       bigdecimal (~> 3.1.8)
       cmath (~> 1.0.0)
       matrix (~> 0.4.2)

--- a/experiments/convolution_speed.rb
+++ b/experiments/convolution_speed.rb
@@ -22,13 +22,13 @@ Benchmark.bmbm do |bench|
 
     bench.report("FFT #{size}") do
       100.times do
-        MB::M.convolve(a1, a2, use_fft: true)
+        MB::M.fftconvolve(a1, a2)
       end
     end
 
     bench.report("Direct #{size}") do
       100.times do
-        MB::M.convolve(a1, a2, use_fft: false)
+        MB::M.convolve(a1, a2)
       end
     end
   end

--- a/experiments/convolution_speed.rb
+++ b/experiments/convolution_speed.rb
@@ -1,0 +1,35 @@
+#!/usr/bin/env ruby
+# Benchmark of FFT vs. direct convolution to see if there's a size below which
+# we should use direct convolution.
+#
+# Usage:
+#     RUBYOPT=--jit ./experiments/convolution_speed.rb
+
+require 'bundler/setup'
+require 'benchmark'
+require 'mb-math'
+
+Benchmark.bmbm do |bench|
+  [5, 10, 50, 100, 500, 1000].each do |size|
+    a1 = Numo::DFloat.linspace(0, 1, size)
+    a2 = MB::M.zpad(Numo::DFloat[1, 0, 0, 1], size)
+
+    bench.report("Pocketfft #{size}") do
+      100.times do
+        Numo::Pocketfft.fftconvolve(a1, a2)
+      end
+    end
+
+    bench.report("FFT #{size}") do
+      100.times do
+        MB::M.convolve(a1, a2, use_fft: true)
+      end
+    end
+
+    bench.report("Direct #{size}") do
+      100.times do
+        MB::M.convolve(a1, a2, use_fft: false)
+      end
+    end
+  end
+end

--- a/lib/mb/m/array_methods.rb
+++ b/lib/mb/m/array_methods.rb
@@ -418,9 +418,9 @@ module MB
       end
 
       # Performs direct convolution of +array1+ with +array2+, returning a new
-      # Numo::NArray with the result.  Uses a naive O(n*m) algorithm which is
-      # faster than FFT-based convolution when array sizes are around 5-10
-      # elements, but otherwise much slower.
+      # Array or Numo::NArray with the result.  Uses a naive O(n*m) algorithm
+      # which is faster than FFT-based convolution when array sizes are around
+      # 5-10 elements, but otherwise much slower.
       #
       # You should use #fftconvolve in most cases, unless exact results are
       # needed.
@@ -437,7 +437,11 @@ module MB
           end
         end
 
-        result = promoted_array_type(array1, array2).zeros(length)
+        if array1.is_a?(Array) && array2.is_a?(Array)
+          result = Array.new(length, 0)
+        else
+          result = promoted_array_type(array1, array2).zeros(length)
+        end
 
         for i in 0...array1.length
           for j in 0...array2.length

--- a/lib/mb/m/array_methods.rb
+++ b/lib/mb/m/array_methods.rb
@@ -449,20 +449,16 @@ module MB
       end
 
       # Uses FFT multiplication to perform fast convolution of +array1+ with
-      # +array2+, which may be 1D Ruby Arrays or Numo::NArrays.
+      # +array2+, which may be 1D Ruby Arrays or Numo::NArrays.  Returns a
+      # Numo::NArray with the result.
       #
-      # If both +array1+ and +array2+ are Numo::NArrays, you should call
-      # Numo::Pocketfft.fftconvolve instead.
+      # If both +array1+ and +array2+ are already Numo::NArrays, you should
+      # consider calling Numo::Pocketfft.fftconvolve directly instead.
       def fftconvolve(array1, array2)
         type = promoted_array_type(array1, array2)
-        length = array1.length + array2.length - 1
-        a1 = zpad(type.cast(array1), length)
-        a2 = zpad(type.cast(array2), length)
-        f1 = Numo::Pocketfft.fft(a1)
-        f2 = Numo::Pocketfft.fft(a2)
-        d = f1 * f2
-        result = Numo::Pocketfft.ifft(d)
-        result = result.real unless a1.is_a?(Numo::SComplex) || a1.is_a?(Numo::DComplex) || a2.is_a?(Numo::SComplex) || a2.is_a?(Numo::DComplex)
+        array1 = type.cast(array1) if array1.is_a?(Array)
+        array2 = type.cast(array2) if array2.is_a?(Array)
+        Numo::Pocketfft.fftconvolve(array1, array2)
       end
 
       # Returns the index of the first element equal to +value+ in the given

--- a/lib/mb/m/numeric_extensions.rb
+++ b/lib/mb/m/numeric_extensions.rb
@@ -31,6 +31,29 @@ module MB
           "#{MB::M.sigfigs(self.abs.to_f, digits).to_f}\u2220#{MB::M.sigfigs(self.arg.to_f.to_degrees, digits).to_f}\u00b0"
         end
 
+        # Formats a number using up to +decimals+ digits after the decimal point.
+        def to_nice_s(decimals = 4)
+          case self
+          when Complex
+            imgs = self.imag.abs.to_nice_s(decimals)
+            imgs = "(#{imgs})" if self.imag.is_a?(Rational)
+            [self.real.to_nice_s(decimals), "#{imgs}i"].join(self.imag > 0 ? '+' : '-')
+
+          when Rational
+            to_s
+
+          when Integer
+            to_s
+
+          else
+            if self.respond_to?(:round) && self.round == self
+              self.round.to_s
+            else
+              ("%.#{decimals.to_i}f" % self).gsub(/\.?0+$/, '')
+            end
+          end
+        end
+
         # Returns a non-augmented rotation matrix of the current numeric in radians.
         #
         # Example:

--- a/lib/mb/m/plot.rb
+++ b/lib/mb/m/plot.rb
@@ -439,6 +439,19 @@ module MB
             end
           end
 
+          # This is a hack doubling down on a poor design.  In the end I might
+          # have to design this in a way that concretely grabs exactly what I
+          # want rather than kind of fuzzing around the prompts and blank lines
+          # and whatnot.  But so be it.
+          #
+          # Limit sequential blank lines to one.
+          prior = nil
+          buf = buf.map { |line, prior|
+            result = line == "" && prior == "" ? nil : line
+            prior = line
+            result
+          }
+
           start_index ||= 0
           lines = buf[start_index..]
 

--- a/lib/mb/m/plot.rb
+++ b/lib/mb/m/plot.rb
@@ -423,9 +423,10 @@ module MB
         3.times do
           buf += read
 
-          while buf.length > 2 && buf.last.include?('plot>')
+          while buf.last.include?('plot>') || buf.last.empty?
             removed = buf.pop
             STDERR.puts("\e[1;38;5;184m[Plot removing #{removed.inspect} from end]\e[0m") if @debug
+            break if removed.include?('plot>')
           end
 
           start_index = buf.rindex { |l| l.include?('plot>') || l.include?('unset multiplot') }&.+(1)

--- a/lib/mb/m/plot.rb
+++ b/lib/mb/m/plot.rb
@@ -480,9 +480,9 @@ module MB
         end
 
         if @print && print
-          puts lines
+          puts colored_lines
         else
-          lines
+          colored_lines
         end
       end
 

--- a/lib/mb/m/plot.rb
+++ b/lib/mb/m/plot.rb
@@ -121,7 +121,7 @@ module MB
       # clears the buffer.
       def read
         @read_mutex.synchronize {
-          STDERR.puts "\e[1;38;5;191m[Plot reading #{@buf.count} with search at #{@buf_idx}, ending at #{@line_index - 1}]\e[0m" if @debug
+          STDERR.puts "\e[1;38;5;191m[Plot reading #{@buf.count} with search at #{@buf_idx}, ending at #{@line_index}]\e[0m" if @debug
           @buf_idx = 0
           @buf.dup.tap { @buf.clear }
         }
@@ -443,7 +443,6 @@ module MB
               row += 1
             else
               in_graph = true
-              colored_lines << ""
             end
           end
 
@@ -453,13 +452,6 @@ module MB
             .gsub(/(?<=[|])-[+]| [+] |[+]-(?=[|])/, "\e[1;35m\\&\e[0m")
             .gsub(/[+]-+[+]|[|]/, "\e[1;30m\\&\e[0m")
         }
-
-        if colored_lines.any? { |l| l.include?('plot>') } # XXX seeing some spurious lines above graphs
-          puts "\e[1;31mBUG: prompt lines present in graph??\e[0m"
-          puts MB::U.highlight(lines)
-          puts MB::U.highlight(colored_lines)
-          binding.pry
-        end
 
         if @print && print
           puts colored_lines

--- a/lib/mb/m/plot.rb
+++ b/lib/mb/m/plot.rb
@@ -418,8 +418,9 @@ module MB
 
       def print_terminal_plot(print)
         lines = nil
+        buf = []
         3.times do
-          buf = read.drop_while { |l|
+          buf += read.drop_while { |l|
             l.include?('plot>') ||
               (l.strip.start_with?(/[[:alpha:]]/) && !l.match?(/[-+*]{3,}/)) ||
               l =~ /^\s*unset multiplot\s*$/

--- a/lib/mb/m/plot.rb
+++ b/lib/mb/m/plot.rb
@@ -433,7 +433,7 @@ module MB
 
           # TODO: use wait_for to make sure we have a full plot
           break if lines
-          STDERR.puts("\e[1;38;5;203m[GNUPLOT looping to find terminal plot; #{buf&.count.inspect} lines so far]\e[0m")
+          STDERR.puts("\e[1;38;5;203m[GNUPLOT looping to find terminal plot; #{buf&.count.inspect} lines so far]\n\t#{buf.map(&:inspect).join("\n\t")}\e[0m")
           sleep 0.1
         end
 

--- a/lib/mb/m/plot.rb
+++ b/lib/mb/m/plot.rb
@@ -115,6 +115,7 @@ module MB
       # clears the buffer.
       def read
         @read_mutex.synchronize {
+          STDERR.puts "\e[1;38;5;191m[GNUPLOT READING #{@buf.count} ending at #{@line_index}]\e[0m" if @debug
           @buf_idx = 0
           @buf.dup.tap { @buf.clear }
         }
@@ -509,13 +510,16 @@ module MB
 
       # Background thread runs this to read GNUplot's output.
       def read_loop
+        @line_index ||= 0
+
         while @run
           line = @stdout.readline.rstrip
           @read_mutex.synchronize {
             @buf << line
           }
 
-          STDERR.puts "\e[33mGNUPLOT: \e[1m#{line}\e[0m" if @debug
+          STDERR.puts "\e[33mGNUPLOT #{@line_index}: \e[1m#{line}\e[0m" if @debug
+          @line_index += 1
         end
 
       rescue StopReadLoop, Errno::EIO

--- a/lib/mb/m/plot.rb
+++ b/lib/mb/m/plot.rb
@@ -430,6 +430,7 @@ module MB
           end
 
           start_index = buf.rindex { |l| l.include?('plot>') || l.include?('unset multiplot') }&.+(1)
+          start_index += 1 if start_index < buf.length && buf[start_index].empty?
           raise "Error: no plot was found within #{buf}" unless buf.count > 3 || start_index
 
           if @debug && start_index

--- a/lib/mb/m/plot.rb
+++ b/lib/mb/m/plot.rb
@@ -433,6 +433,7 @@ module MB
 
           # TODO: use wait_for to make sure we have a full plot
           break if lines
+          STDERR.puts("\e[1;38;5;203m[GNUPLOT looping to find terminal plot; #{buf&.count.inspect} lines so far]\e[0m")
           sleep 0.1
         end
 

--- a/lib/mb/m/precision_methods.rb
+++ b/lib/mb/m/precision_methods.rb
@@ -107,7 +107,9 @@ module MB
       #
       # If +:force_decimal+ is true, then integer values will still print a
       # decimal point.  This is useful for keeping the width of a displayed
-      # value nearly constant.
+      # value nearly constant.  If +:force_decimal+ is false, then no decimal
+      # point will be displayed and effectively 3 figures of precision will be
+      # used.  If +:force_decimal+ is an IntegerThe default is nil.
       #
       # If +:force_sign+ is true, then a plus sign will be placed in front of
       # non-negative values.
@@ -122,7 +124,7 @@ module MB
       #     sigformat(0.12345) # => '123m'
       #     sgiformat(123, 1) # => '100'
       #     sigformat(0.0001234) # => "123\u00b5"
-      def sigformat(value, figs = 3, force_decimal: false, force_sign: false)
+      def sigformat(value, figs = 3, force_decimal: nil, force_sign: false)
         if value != 0
           log = Math.log10(value.abs)
           order = log.floor
@@ -140,9 +142,12 @@ module MB
         sign_prefix = force_sign ? '+' : ''
 
         extra = 1 if extra < 1 && force_decimal
+        extra = force_decimal if force_decimal.is_a?(Integer)
 
-        if !force_decimal && (extra <= 0 || sig == sig.round)
+        if force_decimal == nil && (extra <= 0 || sig == sig.round)
           "%#{sign_prefix}.0f#{prefix}" % sig
+        elsif force_decimal == false
+          "%#{sign_prefix}d#{prefix}" % sig.round
         else
           "%#{sign_prefix}.#{extra}f#{prefix}" % sig
         end

--- a/lib/mb/m/version.rb
+++ b/lib/mb/m/version.rb
@@ -1,5 +1,5 @@
 module MB
   module M
-    VERSION = "0.3.1.usegit"
+    VERSION = "0.4.0.usegit"
   end
 end

--- a/lib/mb/m/version.rb
+++ b/lib/mb/m/version.rb
@@ -1,5 +1,5 @@
 module MB
   module M
-    VERSION = "0.3.0.2.usegit"
+    VERSION = "0.3.1.usegit"
   end
 end

--- a/spec/lib/mb/m/array_methods_spec.rb
+++ b/spec/lib/mb/m/array_methods_spec.rb
@@ -788,6 +788,8 @@ RSpec.describe(MB::M::ArrayMethods, :aggregate_failures) do
     let(:scomplex) { Numo::SComplex[-0.1 - 0.25i, 0.25 - 0.75i, 0.3] }
     let(:dcomplex) { Numo::DComplex[5, -3i, 1i, -1] }
 
+    pending 'fft-specific tests'
+
     it "can produce Pascal's triangle" do
       result = Array.new(5) do |i|
         ([[1, 1]] * (i + 1)).reduce(&MB::M.method(:convolve))

--- a/spec/lib/mb/m/array_methods_spec.rb
+++ b/spec/lib/mb/m/array_methods_spec.rb
@@ -912,7 +912,23 @@ RSpec.describe(MB::M::ArrayMethods, :aggregate_failures) do
     end
   end
 
-  pending '#fftconvolve'
+  describe'#fftconvolve' do
+    it 'accepts Numo::NArrays' do
+      a1 = Numo::SFloat[1,2,3]
+      a2 = Numo::SFloat[1, 0, 0, 1, 1, 0]
+      expected = Numo::SFloat[1, 2, 3, 1, 3, 5, 3, 0]
+
+      expect(MB::M.round(MB::M.fftconvolve(a1, a2), 10)).to eq(expected)
+    end
+
+    it 'accepts Ruby Arrays' do
+      a1 = [1,2,3]
+      a2 = [1, 0, 0, 1, 1, 0]
+      expected = Numo::SFloat[1, 2, 3, 1, 3, 5, 3, 0]
+
+      expect(MB::M.round(MB::M.fftconvolve(a1, a2), 10)).to eq(expected)
+    end
+  end
 
   describe '#find_first' do
     it 'can operate on a Ruby Array' do

--- a/spec/lib/mb/m/array_methods_spec.rb
+++ b/spec/lib/mb/m/array_methods_spec.rb
@@ -788,8 +788,6 @@ RSpec.describe(MB::M::ArrayMethods, :aggregate_failures) do
     let(:scomplex) { Numo::SComplex[-0.1 - 0.25i, 0.25 - 0.75i, 0.3] }
     let(:dcomplex) { Numo::DComplex[5, -3i, 1i, -1] }
 
-    pending 'fft-specific tests'
-
     it "can produce Pascal's triangle" do
       result = Array.new(5) do |i|
         ([[1, 1]] * (i + 1)).reduce(&MB::M.method(:convolve))
@@ -913,6 +911,8 @@ RSpec.describe(MB::M::ArrayMethods, :aggregate_failures) do
       end
     end
   end
+
+  pending '#fftconvolve'
 
   describe '#find_first' do
     it 'can operate on a Ruby Array' do

--- a/spec/lib/mb/m/numeric_extensions_spec.rb
+++ b/spec/lib/mb/m/numeric_extensions_spec.rb
@@ -32,6 +32,24 @@ RSpec.describe(MB::M::NumericExtensions) do
       end
     end
 
+    describe '#to_nice_s' do
+      it 'can format a Complex' do
+        expect((1.2345678-5ri/3).to_nice_s).to eq("1.2346-(5/3)i")
+      end
+
+      it 'can format an integral Float' do
+        expect(1.0.to_nice_s).to eq('1')
+      end
+
+      it 'removes trailing zeros' do
+        expect(-1.5.to_nice_s).to eq('-1.5')
+      end
+
+      it 'can use different precision' do
+        expect(1.2345678.to_nice_s(1)).to eq('1.2')
+      end
+    end
+
     describe '#rotation' do
       it 'can return a 90 degree rotation matrix' do
         expect(90.degree.rotation.round(8)).to eq(Matrix[[0, -1], [1, 0]])

--- a/spec/lib/mb/m/plot_spec.rb
+++ b/spec/lib/mb/m/plot_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe(MB::M::Plot) do
     it 'can plot a Numo::NArray' do
       plot = MB::M::Plot.terminal(width: 80, height: 80, height_fraction: 1)
       lines = plot.plot({data: Numo::SFloat[10, -10, 10, -10, 10]}, print: false)
-      expect(lines.count).to eq(81) # FIXME: why 81?
+      expect(lines.count).to eq(80)
       plot.close
     end
 

--- a/spec/lib/mb/m/plot_spec.rb
+++ b/spec/lib/mb/m/plot_spec.rb
@@ -1,7 +1,7 @@
 require 'fileutils'
 require 'shellwords'
 
-RSpec.describe MB::M::Plot do
+RSpec.describe(MB::M::Plot) do
   describe '#close' do
     it 'closes the plotter' do
       p = MB::M::Plot.terminal(width: 40, height: 20)
@@ -148,7 +148,7 @@ RSpec.describe MB::M::Plot do
     it 'can plot a Numo::NArray' do
       plot = MB::M::Plot.terminal(width: 80, height: 80, height_fraction: 1)
       lines = plot.plot({data: Numo::SFloat[10, -10, 10, -10, 10]}, print: false)
-      expect(lines.count).to be_between(79, 81)
+      expect(lines.count).to eq(81) # FIXME: why 81?
     rescue Exception => e
       raise e.class, "#{e.message}\n\t#{lines.map(&:inspect).join("\n\t")}"
     end
@@ -172,7 +172,7 @@ RSpec.describe MB::M::Plot do
         expect(text).to include('siney ****')
         expect(text).to include('----')
         expect(text).to include('+-+')
-        expect(lines.count).to be_between(79, 81)
+        expect(lines.count).to eq(80)
       rescue Exception => e
         raise e.class, "#{e.message}\n\t#{lines.map(&:inspect).join("\n\t")}"
       end

--- a/spec/lib/mb/m/plot_spec.rb
+++ b/spec/lib/mb/m/plot_spec.rb
@@ -123,13 +123,15 @@ RSpec.describe MB::M::Plot do
         sideways_lines = lines.map { |l| l.ljust(80).chars }.transpose.map(&:join)
         overlapping_lines = sideways_lines.select { |l| l =~ /-(\s+\*+){2,}/ }
         expect(overlapping_lines.count).to be > 4
+      rescue Exception => e
+        raise e.class, "#{e.message}\n\t#{sideways_lines.map(&:inspect).join("\n\t")}\n\n\t#{overlapping_lines.map(&:inspect).join("\n\t")}\n\n\t#{lines.map(&:inspect).join("\n\t")}"
       end
     end
 
     it 'can plot a Numo::NArray' do
       plot = MB::M::Plot.terminal(width: 80, height: 80, height_fraction: 1)
       lines = plot.plot({data: Numo::SFloat[10, -10, 10, -10, 10]}, print: false)
-      expect(lines.count).to be_between(79, 80)
+      expect(lines.count).to be_between(78, 80)
     rescue Exception => e
       raise e.class, "#{e.message}\n\t#{lines.map(&:inspect).join("\n\t")}"
     end
@@ -152,7 +154,8 @@ RSpec.describe MB::M::Plot do
         text = MB::U.remove_ansi(lines.join("\n"))
         expect(text).to include('siney ****')
         expect(text).to include('----')
-        expect(lines.count).to be_between(79, 80)
+        expect(text).to include('+-+')
+        expect(lines.count).to be_between(78, 80)
       rescue Exception => e
         raise e.class, "#{e.message}\n\t#{lines.map(&:inspect).join("\n\t")}"
       end

--- a/spec/lib/mb/m/plot_spec.rb
+++ b/spec/lib/mb/m/plot_spec.rb
@@ -38,6 +38,10 @@ RSpec.describe(MB::M::Plot) do
       }
     }
 
+    after do
+      plot.close
+    end
+
     context 'with the dumb terminal type' do
       it 'can plot to an array of lines' do
         begin
@@ -149,8 +153,7 @@ RSpec.describe(MB::M::Plot) do
       plot = MB::M::Plot.terminal(width: 80, height: 80, height_fraction: 1)
       lines = plot.plot({data: Numo::SFloat[10, -10, 10, -10, 10]}, print: false)
       expect(lines.count).to eq(81) # FIXME: why 81?
-    rescue Exception => e
-      raise e.class, "#{e.message}\n\t#{lines.map(&:inspect).join("\n\t")}"
+      plot.close
     end
 
     it 'raises an error when given something other than a Hash' do
@@ -173,6 +176,7 @@ RSpec.describe(MB::M::Plot) do
         expect(text).to include('----')
         expect(text).to include('+-+')
         expect(lines.count).to eq(80)
+        plot.close
       rescue Exception => e
         raise e.class, "#{e.message}\n\t#{lines.map(&:inspect).join("\n\t")}"
       end

--- a/spec/lib/mb/m/plot_spec.rb
+++ b/spec/lib/mb/m/plot_spec.rb
@@ -129,7 +129,9 @@ RSpec.describe MB::M::Plot do
     it 'can plot a Numo::NArray' do
       plot = MB::M::Plot.terminal(width: 80, height: 80, height_fraction: 1)
       lines = plot.plot({data: Numo::SFloat[10, -10, 10, -10, 10]}, print: false)
-      expect(lines.count).to eq(80)
+      expect(lines.count).to be_between(79, 80)
+    rescue Exception => e
+      raise e.class, "#{e.message}\n\t#{lines.map(&:inspect).join("\n\t")}"
     end
 
     it 'raises an error when given something other than a Hash' do
@@ -150,7 +152,9 @@ RSpec.describe MB::M::Plot do
         text = MB::U.remove_ansi(lines.join("\n"))
         expect(text).to include('siney ****')
         expect(text).to include('----')
-        expect(lines.count).to eq(80)
+        expect(lines.count).to be_between(79, 80)
+      rescue Exception => e
+        raise e.class, "#{e.message}\n\t#{lines.map(&:inspect).join("\n\t")}"
       end
     end
 

--- a/spec/lib/mb/m/plot_spec.rb
+++ b/spec/lib/mb/m/plot_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe MB::M::Plot do
     it 'can plot a Numo::NArray' do
       plot = MB::M::Plot.terminal(width: 80, height: 80, height_fraction: 1)
       lines = plot.plot({data: Numo::SFloat[10, -10, 10, -10, 10]}, print: false)
-      expect(lines.count).to be_between(78, 80)
+      expect(lines.count).to be_between(78, 81)
     rescue Exception => e
       raise e.class, "#{e.message}\n\t#{lines.map(&:inspect).join("\n\t")}"
     end
@@ -155,7 +155,7 @@ RSpec.describe MB::M::Plot do
         expect(text).to include('siney ****')
         expect(text).to include('----')
         expect(text).to include('+-+')
-        expect(lines.count).to be_between(78, 80)
+        expect(lines.count).to be_between(78, 81)
       rescue Exception => e
         raise e.class, "#{e.message}\n\t#{lines.map(&:inspect).join("\n\t")}"
       end

--- a/spec/lib/mb/m/plot_spec.rb
+++ b/spec/lib/mb/m/plot_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe MB::M::Plot do
   describe '#plot' do
     let(:plot) { MB::M::Plot.terminal(width: 80, height: 50) }
     let(:data) { {test123: [1, 0, 0, 0, 0], data321: [1, 0, 1, 0, 0, 0]} }
+    let(:data2) { {d1: [0, 0, 1, 0, 0], d2: [0, 1, 1, 0, 0, 0]} }
     let(:scatter) {
       {
         scatter123: [
@@ -99,7 +100,7 @@ RSpec.describe MB::M::Plot do
         lines = plot.plot(data, columns: 1, rows: 2, print: false)
         border_line = lines.detect { |l| l.include?('----') }
 
-        # Expect the border to be half the screen width
+        # Expect the border to be the full screen width
         expect(border_line.match(/---+/).to_s.length).to be_between(plot.width * 0.7, plot.width)
 
         # Expect the legend of both plots not to be on the same line
@@ -108,6 +109,22 @@ RSpec.describe MB::M::Plot do
 
         second_legend = lines.select { |l| l.include?('test123') }.first
         expect(second_legend).not_to include('data321')
+      end
+
+      it 'can plot using rows and columns' do
+        lines = plot.plot(data.merge(data2), columns: 2, rows: 2, print: false)
+        border_line = lines.detect { |l| l.include?('----') }
+
+        # Expect the border to be half the screen width
+        expect(border_line.match(/\+---+\+/).to_s.length).to be_between(plot.width / 3, plot.width / 2)
+
+        # Expect the legend of first row of plots to be on the same line
+        legend_line = lines.select { |l| l.include?('data321') }.first
+        expect(legend_line).to include('test123')
+
+        # Expect the legend of second row of plots to be on the same line
+        legend_line = lines.select { |l| l.include?('d1') }.first
+        expect(legend_line).to include('d2')
       end
 
       it 'can draw a scatter plot' do
@@ -131,7 +148,7 @@ RSpec.describe MB::M::Plot do
     it 'can plot a Numo::NArray' do
       plot = MB::M::Plot.terminal(width: 80, height: 80, height_fraction: 1)
       lines = plot.plot({data: Numo::SFloat[10, -10, 10, -10, 10]}, print: false)
-      expect(lines.count).to be_between(78, 81)
+      expect(lines.count).to be_between(79, 81)
     rescue Exception => e
       raise e.class, "#{e.message}\n\t#{lines.map(&:inspect).join("\n\t")}"
     end
@@ -155,7 +172,7 @@ RSpec.describe MB::M::Plot do
         expect(text).to include('siney ****')
         expect(text).to include('----')
         expect(text).to include('+-+')
-        expect(lines.count).to be_between(78, 81)
+        expect(lines.count).to be_between(79, 81)
       rescue Exception => e
         raise e.class, "#{e.message}\n\t#{lines.map(&:inspect).join("\n\t")}"
       end

--- a/spec/lib/mb/m/precision_methods_spec.rb
+++ b/spec/lib/mb/m/precision_methods_spec.rb
@@ -265,6 +265,23 @@ RSpec.describe(MB::M::PrecisionMethods) do
       expect(MB::M.sigformat(40000, 4, force_decimal: true)).to eq('40.00k')
     end
 
+    it 'never includes decimals if force_decimal is false' do
+      expect(MB::M.sigformat(1.0, 4, force_decimal: false)).to eq('1')
+      expect(MB::M.sigformat(1000.0, 4, force_decimal: false)).to eq('1k')
+      expect(MB::M.sigformat(0.1001, 4, force_decimal: false)).to eq('100m')
+      expect(MB::M.sigformat(123987654, 4, force_decimal: false)).to eq('124M')
+    end
+
+    it 'accepts a number of decimals for force_decimal' do
+      expect(MB::M.sigformat(1.0, 4, force_decimal: 1)).to eq('1.0')
+      expect(MB::M.sigformat(1000, 4, force_decimal: 1)).to eq('1.0k')
+      expect(MB::M.sigformat(1000, 1, force_decimal: 3)).to eq('1.000k')
+      expect(MB::M.sigformat(0.01234, 2, force_decimal: 3)).to eq('12.000m')
+      expect(MB::M.sigformat(0.0123456, 4, force_decimal: 3)).to eq('12.350m')
+      expect(MB::M.sigformat(0.0123456, 7, force_decimal: 3)).to eq('12.346m')
+      expect(MB::M.sigformat(0.0123456, 7, force_decimal: 4)).to eq('12.3456m')
+    end
+
     it 'honors force_sign for displayed integers' do
       expect(MB::M.sigformat(0, force_sign: true)).to eq('+0')
       expect(MB::M.sigformat(0.0 * -1.0, force_sign: true)).to eq('-0')


### PR DESCRIPTION
Fixes and new features required for the upcoming implementation of wavetable synthesis in https://github.com/mike-bourgeous/mb-sound/.

- Fixed terminal plots (no more random blank or missing lines)
- Added FFT-based convolution (wrote my own but then switched to Pocketfft's version).  This is for implementing autocorrelation and cross-correlation in mb-sound.
- Added `Numeric#to_nice_s` and improved `MB::M.sigformat` to aid in formatting numbers for UI display.

Blocks https://github.com/mike-bourgeous/mb-sound/pull/47