### PR TITLE
Add matrix and vector methods to aid mb-sound reverb implementation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 PATH
   remote: .
   specs:
-    mb-math (0.4.2.usegit)
+    mb-math (0.4.3.usegit)
       bigdecimal (~> 3.1.8)
       cmath (~> 1.0.0)
       matrix (~> 0.4.2)

--- a/lib/mb/m.rb
+++ b/lib/mb/m.rb
@@ -18,6 +18,7 @@ require_relative 'm/trig_methods'
 require_relative 'm/regression_methods'
 require_relative 'm/root_methods'
 require_relative 'm/random_methods'
+require_relative 'm/matrix_methods'
 
 module MB
   # Functions for clamping, scaling, interpolating, etc.  Extracted from
@@ -40,6 +41,7 @@ module MB
     extend RegressionMethods
     extend RootMethods
     extend RandomMethods
+    extend MatrixMethods
 
     # Parses +v+ as a Float or Complex.  Supports polar notation using degrees
     # separated by a less-than sign, with or without spaces.

--- a/lib/mb/m.rb
+++ b/lib/mb/m.rb
@@ -19,6 +19,7 @@ require_relative 'm/regression_methods'
 require_relative 'm/root_methods'
 require_relative 'm/random_methods'
 require_relative 'm/matrix_methods'
+require_relative 'm/vector_methods'
 
 module MB
   # Functions for clamping, scaling, interpolating, etc.  Extracted from
@@ -41,7 +42,9 @@ module MB
     extend RegressionMethods
     extend RootMethods
     extend RandomMethods
+
     extend MatrixMethods
+    extend VectorMethods
 
     # Parses +v+ as a Float or Complex.  Supports polar notation using degrees
     # separated by a less-than sign, with or without spaces.

--- a/lib/mb/m/array_methods.rb
+++ b/lib/mb/m/array_methods.rb
@@ -399,6 +399,49 @@ module MB
         array[idx]
       end
 
+      # Retrieves the value at index +idx+ from the +array+, wrapping around at
+      # either end.
+      #
+      # Example:
+      #     MB::M.fetch_wrap(Numo::SFloat[1, 2], 2)
+      #     # => 1
+      def fetch_wrap(array, idx)
+        array[idx % array.length]
+      end
+
+      # Retrieves the value at index +idx+ from the +array+, replacing
+      # out-of-bounds values with the given +before+ and +after+ values
+      # (+after+ defaults to +before+).
+      #
+      # Example:
+      #     MB::M.fetch_constant(Numo::SFloat[1, 2], 2)
+      #     # => 2
+      def fetch_constant(array, idx, before = 0, after = before)
+        if idx < 0
+          before
+        elsif idx > array.length - 1
+          after
+        else
+          array[idx]
+        end
+      end
+
+      # Retrieves the value at index +idx+ from the +array+, clamping indices
+      # to the start and end of the array.
+      #
+      # Example:
+      #     MB::M.fetch_clamp(Numo::SFloat[1, 2], 2)
+      #     # => 2
+      def fetch_clamp(array, idx)
+        if idx < 0
+          array[0]
+        elsif idx > array.length - 1
+          array[-1]
+        else
+          array[idx]
+        end
+      end
+
       # Repeatedly copies +:source+ into +:destination+, starting at the given
       # +:source_offset+.  Wraps around +:source+ at the end, but does not wrap
       # around +:destination+.  Both +:source+ and +:destination+ should be
@@ -424,6 +467,9 @@ module MB
       # Interpolates between values neighboring +index+ in the given +array+,
       # optionally using a given interpolation function.  See
       # InterpolationMethods#interp.
+      #
+      # TODO: consider some unifying design between this method,
+      # InterpolationMethods#cubic_lookup, etc.
       def fractional_index(array, index, func: nil)
         i1 = index.floor
         i2 = index.ceil

--- a/lib/mb/m/interpolation_methods.rb
+++ b/lib/mb/m/interpolation_methods.rb
@@ -61,7 +61,6 @@ module MB
       # TODO: support other data types like #interp does?
       def cubic_interp(y1, d1, y2, d2, blend)
         # https://math.stackexchange.com/a/1522453/730912
-
         xmat = Matrix[
           [0, 0, 0, 1],
           [1, 1, 1, 1],
@@ -78,7 +77,6 @@ module MB
         coeff = xmat.inv * ymat
 
         ret = coeff[0,0] * blend ** 3 + coeff[1,0] * blend ** 2 + coeff[2,0] * blend + coeff[3,0]
-        puts "  #{ret}\n\n"
         ret
       end
 

--- a/lib/mb/m/interpolation_methods.rb
+++ b/lib/mb/m/interpolation_methods.rb
@@ -54,6 +54,45 @@ module MB
         end
       end
 
+      # Uses +a+ and +d+ as context to blend between +b+ and +c+ with a
+      # piecewise cubic function fit to (-1, a), (0, b), (1, c), (2, d).
+      def cubic_maybe(a, b, c, d, blend)
+        puts "#{a}, #{b}, #{c}, #{d}, #{blend}"
+
+        xmat = Matrix[
+          [-1, 1, -1, 1],
+          [0, 0, 0, 1],
+          [1, 1, 1, 1],
+          [8, 4, 2, 1]
+        ]
+        ymat = Matrix[
+          [a],
+          [b],
+          [c],
+          [d]
+        ]
+
+        coeff = xmat.inv * ymat
+
+        ret = coeff[0,0] * blend ** 3 + coeff[1,0] * blend ** 2 + coeff[2,0] * blend + coeff[3,0]
+        puts "  #{ret}\n\n"
+        ret
+      end
+
+      def cubic_lookup(array, idx)
+        # TODO option for end behavior (zero, wrap, bounce)
+        idx %= array.length
+        ifloor = idx.floor
+        ifrac = idx - ifloor
+        cubic_maybe(
+          array[ifloor - 1],
+          array[ifloor],
+          array[(ifloor + 1) % array.length],
+          array[(ifloor + 2) % array.length],
+          ifrac
+        )
+      end
+
       # Turns +path+, an Array of keys and indexes from navigating nested
       # Arrays and Hashes, into a String representing the path.
       def path_string(path, prefix: '')

--- a/lib/mb/m/matrix_methods.rb
+++ b/lib/mb/m/matrix_methods.rb
@@ -1,0 +1,34 @@
+module MB
+  module M
+    # Methods related to the creation, modification, and use of matrices.
+    module MatrixMethods
+      # Uses Sylvester's construction, as documented on Wikipedia, to construct
+      # a power-of-two-sized Hadamard matrix.  The elements of the returned
+      # matrix will be either 1 or -1, and the rows will be orthogonal.
+      #
+      # Returns a row-major Array of Arrays.  To convert to a Matrix, use
+      # `Matrix[*hadamard(n)]`.  To convert to a Numo::NArray, use e.g.
+      # `Numo::SFloat.cast(hadamard(n))`.
+      def hadamard(order)
+        raise 'Order must be a power of two (e.g. 1, 2, 4, 8, 16, ...)' unless 2 ** Math.log2(order).floor == order
+
+        case order
+        when 1
+          [[1]]
+
+        when 2
+          [[1, 1], [1, -1]]
+        
+        else
+          prior_size = order / 2
+          prior = hadamard(prior_size)
+
+          top_half = prior.map { |p| p * 2 }
+          bottom_half = prior.map { |p| p + p.map(&:-@) }
+
+          top_half + bottom_half
+        end
+      end
+    end
+  end
+end

--- a/lib/mb/m/vector_methods.rb
+++ b/lib/mb/m/vector_methods.rb
@@ -14,7 +14,7 @@ module MB
           if vdot.is_a?(Numo::NArray)
             # Treat Vector of NArrays as time series of vectors
             vector.map.with_index { |c, idx|
-              c - vdot * (2.0 * nmag / normal[idx])
+              c - vdot * (2.0 / (nmag * normal[idx]))
             }
           else
             vector - 2 * vdot / nmag * normal

--- a/lib/mb/m/vector_methods.rb
+++ b/lib/mb/m/vector_methods.rb
@@ -1,0 +1,28 @@
+module MB
+  module M
+    # Methods on MB::M for working with vectors.
+    module VectorMethods
+      # Reflects the +vector+ across the (hyper)plane through the origin
+      # defined by the given +normal+ vector.
+      def reflect(vector, normal)
+        case vector
+        when Vector
+          vdot = vector.dot(normal)
+          vdot = vdot.to_r if vdot.is_a?(Integer)
+          vector - 2 * vdot / normal.dot(normal) * normal
+
+        when Numo::NArray
+          dot = (vector * normal).sum
+          normdot = (normal * normal).sum
+          vector - 2 * dot / normdot * normal
+
+        when Array
+          reflect(Vector[*vector], Vector[*normal]).to_a
+
+        else
+          raise "Unsupported type #{vector.class}"
+        end
+      end
+    end
+  end
+end

--- a/lib/mb/m/vector_methods.rb
+++ b/lib/mb/m/vector_methods.rb
@@ -9,7 +9,16 @@ module MB
         when Vector
           vdot = vector.dot(normal)
           vdot = vdot.to_r if vdot.is_a?(Integer)
-          vector - 2 * vdot / normal.dot(normal) * normal
+          nmag = normal.dot(normal)
+
+          if vdot.is_a?(Numo::NArray)
+            # Treat Vector of NArrays as time series of vectors
+            vector.map.with_index { |c, idx|
+              c - vdot * (2.0 * nmag / normal[idx])
+            }
+          else
+            vector - 2 * vdot / nmag * normal
+          end
 
         when Numo::NArray
           dot = (vector * normal).sum

--- a/lib/mb/m/version.rb
+++ b/lib/mb/m/version.rb
@@ -1,5 +1,5 @@
 module MB
   module M
-    VERSION = "0.4.2.usegit"
+    VERSION = "0.4.3.usegit"
   end
 end

--- a/spec/lib/mb/m/array_methods_spec.rb
+++ b/spec/lib/mb/m/array_methods_spec.rb
@@ -777,6 +777,78 @@ RSpec.describe(MB::M::ArrayMethods, :aggregate_failures) do
     end
   end
 
+  describe '#fetch_wrap' do
+    it 'can retrieve in-bounds indices' do
+      expect(MB::M.fetch_wrap([1, 2], 0)).to eq(1)
+      expect(MB::M.fetch_wrap(Numo::Int64[1, 2], 0)).to eq(1)
+    end
+
+    it 'works with the documentation example' do
+      expect(MB::M.fetch_wrap(Numo::SFloat[1, 2], 2)).to eq(1)
+    end
+
+    it 'wraps negative indices' do
+      expect(MB::M.fetch_wrap([1, 2], -2)).to eq(1)
+      expect(MB::M.fetch_wrap([1, 2], -3)).to eq(2)
+    end
+
+    it 'wraps indices past the end' do
+      expect(MB::M.fetch_wrap([1, 2, 3], 3)).to eq(1)
+      expect(MB::M.fetch_wrap([1, 2, 3], 4)).to eq(2)
+      expect(MB::M.fetch_wrap([1, 2, 3], 5)).to eq(3)
+      expect(MB::M.fetch_wrap([1, 2, 3], 6)).to eq(1)
+      expect(MB::M.fetch_wrap([1, 2, 3], 37)).to eq(2)
+      expect(MB::M.fetch_wrap(Numo::Int32[1, 2, 3], 37)).to eq(2)
+    end
+  end
+
+  describe '#fetch_constant' do
+    it 'can retrieve in-bounds indices' do
+      expect(MB::M.fetch_constant([1, 2], 0)).to eq(1)
+      expect(MB::M.fetch_constant(Numo::Int64[1, 2], 0)).to eq(1)
+    end
+
+    it 'defaults to extending with zeros' do
+      expect(MB::M.fetch_constant([1, 2], 2)).to eq(0)
+      expect(MB::M.fetch_constant([1, 2], 42)).to eq(0)
+      expect(MB::M.fetch_constant([1, 2], -1)).to eq(0)
+      expect(MB::M.fetch_constant(Numo::DFloat[1, 2], -100)).to eq(0)
+    end
+
+    it 'can extend with a given constant' do
+      expect(MB::M.fetch_constant([1, 2], 2, 1i)).to eq(1i)
+      expect(MB::M.fetch_constant([1, 2], 42, 1i)).to eq(1i)
+      expect(MB::M.fetch_constant(Numo::SComplex[1, 2], -1, 1i)).to eq(1i)
+      expect(MB::M.fetch_constant([1, 2], -100, 1i)).to eq(1i)
+    end
+
+    it 'can use different constants before and after' do
+      expect(MB::M.fetch_constant([1, 2], 2, -2i, 1i)).to eq(1i)
+      expect(MB::M.fetch_constant(Numo::DComplex[1, 2], 42, -2i, 1i)).to eq(1i)
+      expect(MB::M.fetch_constant([1, 2], -1, -2i, 1i)).to eq(-2i)
+      expect(MB::M.fetch_constant([1, 2], -100, -2i, 1i)).to eq(-2i)
+    end
+  end
+
+  describe '#fetch_clamp' do
+    it 'can retrieve in-bounds indices' do
+      expect(MB::M.fetch_clamp([1, 2], 0)).to eq(1)
+      expect(MB::M.fetch_clamp(Numo::DFloat[1, 2], 0)).to eq(1)
+    end
+
+    it 'clamps negative indices to the start of the array' do
+      expect(MB::M.fetch_clamp([1, 2], -1)).to eq(1)
+      expect(MB::M.fetch_clamp([1, 2], -13)).to eq(1)
+      expect(MB::M.fetch_clamp(Numo::SFloat[1, 2], -13)).to eq(1)
+    end
+
+    it 'clamps large indices to the end of the array' do
+      expect(MB::M.fetch_clamp([1, 2], 2)).to eq(2)
+      expect(MB::M.fetch_clamp([1, 2], 24)).to eq(2)
+      expect(MB::M.fetch_clamp(Numo::SFloat[1, 2], 24)).to eq(2)
+    end
+  end
+
   describe '.fractional_index' do
     let(:array) { [ 1, 3, 5, -5, 1.5, 2.5 + 1.0i, 1.0 - 1.0i ] }
     let(:narray) { Numo::SComplex[1, 3, 5i] }

--- a/spec/lib/mb/m/interpolation_methods_spec.rb
+++ b/spec/lib/mb/m/interpolation_methods_spec.rb
@@ -162,6 +162,9 @@ RSpec.describe(MB::M::InterpolationMethods) do
     end
   end
 
+  pending '#cubic_interp'
+  pending '#cubic_lookup'
+
   describe '#deep_math' do
     it 'can multiply Strings just because it was more work to avoid it' do
       expect(MB::M.deep_math(['a', {b: 'c'}], :*, 3)).to eq(['aaa', {b: 'ccc'}])

--- a/spec/lib/mb/m/matrix_methods_spec.rb
+++ b/spec/lib/mb/m/matrix_methods_spec.rb
@@ -1,0 +1,29 @@
+RSpec.describe(MB::M::MatrixMethods) do
+  describe '#hadamard' do
+    it 'raises an error for a non-power-of-two order' do
+      expect { MB::M.hadamard(3) }.to raise_error(/power.*two/i)
+    end
+
+    it 'returns the expected order-4 matrix' do
+      expect(MB::M.hadamard(4)).to eq([
+        [1, 1, 1, 1],
+        [1, -1, 1, -1],
+        [1, 1, -1, -1],
+        [1, -1, -1, 1],
+      ])
+    end
+
+    for exponent in 0..10 do
+      order = 1 << exponent
+      it "can create an order-#{order} matrix with the expected properties" do
+        h = MB::M.hadamard(order)
+        m = Matrix[*m]
+        sf = Numo::SFloat.cast(h)
+
+        expect(Matrix[*m]).to be_symmetric
+        expect(sf.minmax).to eq([-1, 1])
+        expect(h.flatten.uniq.sort).to eq([-1, 1])
+      end
+    end
+  end
+end

--- a/spec/lib/mb/m/vector_methods_spec.rb
+++ b/spec/lib/mb/m/vector_methods_spec.rb
@@ -43,8 +43,6 @@ RSpec.describe(MB::M::VectorMethods, aggregate_failures: true) do
           normal: [1, 1, 1, 1, 1],
           result: [-1r/5, -16r/5, 9r/5, -26r/5, 19r/5],
         },
-
-        # TODO: Vector of NArrays for array of vector processing
       ]
     }
 
@@ -55,7 +53,7 @@ RSpec.describe(MB::M::VectorMethods, aggregate_failures: true) do
           n = argmap.call(c[:normal])
           r = argmap.call(c[:result])
 
-          expect(MB::M.round(MB::M.reflect(v, n), 6)).to eq(MB::M.round(r, 6))
+          expect(MB::M.reflect(v, n)).to all_be_within(1e-6).of_array(r)
         end
       end
     end
@@ -73,6 +71,24 @@ RSpec.describe(MB::M::VectorMethods, aggregate_failures: true) do
     context 'with Array' do
       let(:argmap) { ->(d) { d } }
       it_behaves_like('planar reflection')
+    end
+
+    it 'processes a vector of narrays as an array of vectors' do
+      vector = Vector[
+        Numo::SFloat[1, 1],
+        Numo::SFloat[2, -2],
+        Numo::SFloat[3, 3],
+        Numo::SFloat[4, -4],
+        Numo::SFloat[5, 5],
+      ]
+      normal = Vector[1, 1, 1, 1, 1]
+      expect(MB::M.reflect(vector, normal)).to all_be_within(1e-6).of_array(Vector[
+        Numo::SFloat[-5, -1.0/5.0],
+        Numo::SFloat[-4, -16.0/5.0],
+        Numo::SFloat[-3, 9.0/5.0],
+        Numo::SFloat[-2, -26.0/5.0],
+        Numo::SFloat[-1, 19.0/5.0],
+      ])
     end
   end
 end

--- a/spec/lib/mb/m/vector_methods_spec.rb
+++ b/spec/lib/mb/m/vector_methods_spec.rb
@@ -1,0 +1,76 @@
+RSpec.describe(MB::M::VectorMethods, aggregate_failures: true) do
+  describe '#reflect' do
+    let(:cases) {
+      [
+        {
+          vector: [1, 2, 3],
+          normal: [1, 0, 0],
+          result: [-1, 2, 3],
+        },
+        {
+          vector: [1, 2, 3],
+          normal: [0, 1, 0],
+          result: [1, -2, 3],
+        },
+        {
+          vector: [1, 2, 3],
+          normal: [0, 0, 1],
+          result: [1, 2, -3],
+        },
+        {
+          vector: [1, 2, 3, 4],
+          normal: [0, 0, 0, 4],
+          result: [1, 2, 3, -4],
+        },
+        {
+          vector: [-2, 5],
+          normal: [1, 1],
+          result: [-5, 2],
+        },
+        {
+          # opposite normal, same plane
+          vector: [-2, 5],
+          normal: [-1, -1],
+          result: [-5, 2],
+        },
+        {
+          vector: [1, 2, 3, 4, 5],
+          normal: [1, 1, 1, 1, 1],
+          result: [-5, -4, -3, -2, -1],
+        },
+        {
+          vector: [1, -2, 3, -4, 5],
+          normal: [1, 1, 1, 1, 1],
+          result: [-1r/5, -16r/5, 9r/5, -26r/5, 19r/5],
+        },
+      ]
+    }
+
+    shared_examples_for('planar reflection') do
+      it 'returns the expected result for various test cases' do
+        cases.each do |c|
+          v = argmap.call(c[:vector])
+          n = argmap.call(c[:normal])
+          r = argmap.call(c[:result])
+
+          expect(MB::M.round(MB::M.reflect(v, n), 6)).to eq(MB::M.round(r, 6))
+        end
+      end
+    end
+
+    context 'with Vector' do
+      let(:argmap) { ->(d) { Vector[*d] } }
+      it_behaves_like('planar reflection')
+    end
+
+    context 'with Numo::SFloat' do
+      let(:argmap) { ->(d) { Numo::SFloat.cast(d) } }
+      it_behaves_like('planar reflection')
+    end
+
+    context 'with Array' do
+      let(:argmap) { ->(d) { d } }
+      it_behaves_like('planar reflection')
+    end
+  end
+end

--- a/spec/lib/mb/m/vector_methods_spec.rb
+++ b/spec/lib/mb/m/vector_methods_spec.rb
@@ -43,6 +43,8 @@ RSpec.describe(MB::M::VectorMethods, aggregate_failures: true) do
           normal: [1, 1, 1, 1, 1],
           result: [-1r/5, -16r/5, 9r/5, -26r/5, 19r/5],
         },
+
+        # TODO: Vector of NArrays for array of vector processing
       ]
     }
 


### PR DESCRIPTION
These matrix/vector operations are part of the simple reverb algorithm described by Geraint Luff and recently implemented in mb-sound.

Reference video for reverb algorithm: https://www.youtube.com/watch?v=6ZK2Goiyotk ("Let's write a reverb - Geraint Luff - ADC21")

Reverb implementation live stream: https://www.youtube.com/watch?v=HfIXHN4B22M [this video will be removed in favor of a summary eventually]

Blocks https://github.com/mike-bourgeous/mb-sound/pull/53