### PR TITLE
Fix plot parsing in docker container when gnuplot echoes input

### DIFF
--- a/lib/mb/m/plot.rb
+++ b/lib/mb/m/plot.rb
@@ -91,7 +91,7 @@ module MB
 
         @buf = []
         @buf_idx = 0 # offset in the buf where we left off looking for something
-        @stdout, @stdin, @pid = PTY.spawn('stty -echo ; gnuplot')
+        @stdout, @stdin, @pid = PTY.spawn('stty -echo ; gnuplot') # FIXME: echo stays on inside Docker container
 
         # Disable echo-back on the PTY
         @stdin.raw!
@@ -146,9 +146,22 @@ module MB
         read.tap { |lines|
           prior_count = lines.length
 
+          # Remove all lines after and including the marker line
           d = ''
           d = lines.pop until d.include?(marker)
-          d = lines.shift while lines.first&.strip&.end_with?('plot>')
+
+          # Remove the leading prompt line(s)
+          lines.shift while lines.first&.strip&.end_with?('plot>')
+
+          # CONTAINER HACK
+          # Remove lines with the prompt included, and remove the blank line
+          # afterward if present.  Some Docker containers or other environments
+          # return the command on the same line as the prompt, while others
+          # (GitHub CI and my own desktop) have it on a separate line.
+          if lines.first&.include?('plot>')
+            lines.shift
+            lines.shift if lines.first&.strip&.empty?
+          end
 
           STDERR.puts "\e[35m[Plot command response received: #{lines.length} lines out of #{prior_count}]\n\e[1m>#{lines.join("\n>")}\e[0m" if @debug
         }

--- a/lib/mb/m/plot.rb
+++ b/lib/mb/m/plot.rb
@@ -91,10 +91,12 @@ module MB
 
         @buf = []
         @buf_idx = 0 # offset in the buf where we left off looking for something
-        @stdout, @stdin, @pid = PTY.spawn('stty -echo ; gnuplot') # FIXME: echo stays on inside Docker container
-
-        # Disable echo-back on the PTY
-        @stdin.raw!
+        # Use a pipe for gnuplot's stdin so it sees a non-tty input and
+        # does not echo commands or print prompts (gnuplot 6.0+ echoes
+        # input via readline when it detects a terminal).
+        @gnuplot_stdin_r, @stdin = IO.pipe
+        @stdout, _pty_stdin, @pid = PTY.spawn('gnuplot', in: @gnuplot_stdin_r)
+        @gnuplot_stdin_r.close
 
         @run = true
         @debug = ENV['PLOT_DEBUG'] == '1'
@@ -146,22 +148,12 @@ module MB
         read.tap { |lines|
           prior_count = lines.length
 
-          # Remove all lines after and including the marker line
           d = ''
           d = lines.pop until d.include?(marker)
-
-          # Remove the leading prompt line(s)
-          lines.shift while lines.first&.strip&.end_with?('plot>')
-
-          # CONTAINER HACK
-          # Remove lines with the prompt included, and remove the blank line
-          # afterward if present.  Some Docker containers or other environments
-          # return the command on the same line as the prompt, while others
-          # (GitHub CI and my own desktop) have it on a separate line.
-          if lines.first&.include?('plot>')
-            lines.shift
-            lines.shift if lines.first&.strip&.empty?
-          end
+          # The \n before the marker in the print command leaves a trailing
+          # blank line; remove it
+          lines.pop if lines.last&.strip&.empty?
+          d = lines.shift while lines.first&.strip&.end_with?('plot>')
 
           STDERR.puts "\e[35m[Plot command response received: #{lines.length} lines out of #{prior_count}]\n\e[1m>#{lines.join("\n>")}\e[0m" if @debug
         }

--- a/lib/mb/m/plot.rb
+++ b/lib/mb/m/plot.rb
@@ -134,7 +134,7 @@ module MB
       def command(cmd)
         raise PlotError, 'Plot is closed' unless @stdin
 
-        cmd_id = SecureRandom.uuid
+        cmd_id = SecureRandom.base64(9)
         marker = "done #{cmd_id}"
         cmdline = "#{cmd} ; print \"\\n\\144\\157\\156\\145 #{cmd_id}\""
 

--- a/lib/mb/m/plot.rb
+++ b/lib/mb/m/plot.rb
@@ -91,12 +91,10 @@ module MB
 
         @buf = []
         @buf_idx = 0 # offset in the buf where we left off looking for something
-        # Use a pipe for gnuplot's stdin so it sees a non-tty input and
-        # does not echo commands or print prompts (gnuplot 6.0+ echoes
-        # input via readline when it detects a terminal).
-        @gnuplot_stdin_r, @stdin = IO.pipe
-        @stdout, _pty_stdin, @pid = PTY.spawn('gnuplot', in: @gnuplot_stdin_r)
-        @gnuplot_stdin_r.close
+        @stdout, @stdin, @pid = PTY.spawn('stty -echo ; gnuplot') # FIXME: echo stays on inside Docker container
+
+        # Disable echo-back on the PTY
+        @stdin.raw!
 
         @run = true
         @debug = ENV['PLOT_DEBUG'] == '1'
@@ -148,12 +146,22 @@ module MB
         read.tap { |lines|
           prior_count = lines.length
 
+          # Remove all lines after and including the marker line
           d = ''
           d = lines.pop until d.include?(marker)
-          # The \n before the marker in the print command leaves a trailing
-          # blank line; remove it
-          lines.pop if lines.last&.strip&.empty?
-          d = lines.shift while lines.first&.strip&.end_with?('plot>')
+
+          # Remove the leading prompt line(s)
+          lines.shift while lines.first&.strip&.end_with?('plot>')
+
+          # CONTAINER HACK
+          # Remove lines with the prompt included, and remove the blank line
+          # afterward if present.  Some Docker containers or other environments
+          # return the command on the same line as the prompt, while others
+          # (GitHub CI and my own desktop) have it on a separate line.
+          if lines.first&.include?('plot>')
+            lines.shift
+            lines.shift if lines.first&.strip&.empty?
+          end
 
           STDERR.puts "\e[35m[Plot command response received: #{lines.length} lines out of #{prior_count}]\n\e[1m>#{lines.join("\n>")}\e[0m" if @debug
         }


### PR DESCRIPTION
I was doing some experimentation in a Docker container using the `ruby-3.4` base Docker image, and the GNUplot output is different -- it echoes the command lines even though I've explicitly disabled echo using both stty and the `raw!` command.  This change allows MB::M::Plot to work in that environment without breaking it in the known-good GitHub CI and my own desktop.